### PR TITLE
Feat/igw 25/24 - 서류 관리 메인 페이지 퍼블리싱

### DIFF
--- a/src/assets/icons/AddButton.svg
+++ b/src/assets/icons/AddButton.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Add">
+<circle id="Ellipse 64" opacity="0.2" cx="12" cy="12" r="12" fill="black" fill-opacity="0.2"/>
+<path id="Vector 71" d="M12 8V16" stroke="#1E1926" stroke-width="1.5" stroke-linecap="round"/>
+<path id="Vector 72" d="M16 12L8 12" stroke="#1E1926" stroke-width="1.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/assets/icons/CheckIconGreen.svg
+++ b/src/assets/icons/CheckIconGreen.svg
@@ -1,0 +1,5 @@
+<svg width="19" height="15" viewBox="0 0 19 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Iconography">
+<path id="Path 5" d="M14.8217 4.67878L8.38917 11.2917L3.34996 7.07705" stroke="#00D1A0" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assets/icons/DownloadIcon.svg
+++ b/src/assets/icons/DownloadIcon.svg
@@ -1,0 +1,7 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Iconography">
+<path id="Path 5" d="M11.177 5.99316L6.99964 10.1705L2.82227 5.99316" stroke="#222222" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Path 7" d="M1.42969 12.2592H12.5694" stroke="#222222" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Path 7_2" d="M6.99935 1.16699V9.33366" stroke="#222222" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assets/icons/FolderIcon.svg
+++ b/src/assets/icons/FolderIcon.svg
@@ -1,0 +1,5 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Iconography">
+<path id="Path" fill-rule="evenodd" clip-rule="evenodd" d="M0.585938 2.82102C0.585937 2.12326 1.14526 1.55762 1.83522 1.55762H4.39274L5.86539 3.11257H10.1637C10.8537 3.11257 11.413 3.67821 11.413 4.37597V9.42957C11.413 10.1273 10.8537 10.693 10.1637 10.693H1.83522C1.14526 10.693 0.585938 10.1273 0.585938 9.42957V2.82102Z" stroke="#F4F4F9" stroke-width="0.8" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assets/icons/TalkBalloon.svg
+++ b/src/assets/icons/TalkBalloon.svg
@@ -1,0 +1,8 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Iconography">
+<path id="Path" fill-rule="evenodd" clip-rule="evenodd" d="M9.73416 13.4482C9.73416 13.1169 9.46553 12.8482 9.13416 12.8482H6.80165C3.99876 12.8482 1.72656 10.5525 1.72656 7.72051C1.72656 4.88854 3.99876 2.59277 6.80165 2.59277H11.2001C14.0029 2.59277 16.2751 4.88854 16.2751 7.72051C16.2751 7.72051 16.2751 10.403 13.3785 13.0851C12.8425 13.5416 11.3006 14.9345 10.4034 15.7476C10.146 15.9808 9.73416 15.7977 9.73416 15.4504V13.4482Z" stroke="#222222" stroke-width="0.8" stroke-linecap="round"/>
+<circle id="Oval" cx="5.96542" cy="7.60213" r="0.385338" stroke="#222222" stroke-width="0.8" stroke-linecap="round"/>
+<ellipse id="Oval Copy" cx="9.04745" cy="7.60213" rx="0.385338" ry="0.385338" stroke="#222222" stroke-width="0.8" stroke-linecap="round"/>
+<ellipse id="Oval Copy 2" cx="12.1295" cy="7.60213" rx="0.385338" ry="0.385338" stroke="#222222" stroke-width="0.8" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/assets/icons/TalkBalloonGrey.svg
+++ b/src/assets/icons/TalkBalloonGrey.svg
@@ -1,0 +1,8 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Iconography">
+<path id="Path" fill-rule="evenodd" clip-rule="evenodd" d="M7.56993 10.5931C7.56993 10.2617 7.3013 9.99307 6.96993 9.99307H5.28909C3.10906 9.99307 1.3418 8.20748 1.3418 6.00484C1.3418 3.8022 3.10906 2.0166 5.28909 2.0166H8.71007C10.8901 2.0166 12.6574 3.8022 12.6574 6.00484C12.6574 6.00484 12.6574 8.09121 10.4045 10.1773C10.0159 10.5082 8.94767 11.4718 8.23928 12.1133C7.98184 12.3464 7.56993 12.1633 7.56993 11.816V10.5931Z" stroke="#F4F4F9" stroke-width="0.8" stroke-linecap="round"/>
+<circle id="Oval" cx="4.63955" cy="5.91299" r="0.299707" stroke="#F4F4F9" stroke-width="0.8" stroke-linecap="round"/>
+<circle id="Oval Copy" cx="7.03604" cy="5.91299" r="0.299707" stroke="#F4F4F9" stroke-width="0.8" stroke-linecap="round"/>
+<circle id="Oval Copy 2" cx="9.43447" cy="5.91299" r="0.299707" stroke="#F4F4F9" stroke-width="0.8" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/assets/icons/WriteIcon.svg
+++ b/src/assets/icons/WriteIcon.svg
@@ -1,0 +1,7 @@
+<svg width="18" height="14" viewBox="0 0 18 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Iconography">
+<path id="Rectangle" fill-rule="evenodd" clip-rule="evenodd" d="M13.9714 1.26193C14.6882 1.82472 14.6882 2.73718 13.9714 3.29997L5.20964 10.1783L2.28906 10.4331L2.61357 8.14029L11.3753 1.26193C12.0922 0.699147 13.2545 0.699147 13.9714 1.26193Z" stroke="#222222" stroke-width="1.2" stroke-linejoin="round"/>
+<path id="Path 12 Copy 4" d="M3.80132 7.44554L4.25169 7.79911L6.09654 9.24739" stroke="#222222" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector 1" d="M2.11523 13.207H16.1545" stroke="#222222" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/Document/DocumentCard.tsx
+++ b/src/components/Document/DocumentCard.tsx
@@ -72,7 +72,7 @@ const TemporarySaveCard = ({
           fontColor="text-[#222]"
           isBorder={false}
           title="Edit"
-          onClick={() => onNext}
+          onClick={onNext}
         />
         <Button
           type="large"
@@ -80,7 +80,7 @@ const TemporarySaveCard = ({
           fontColor="text-[#222]"
           isBorder={false}
           title="Submit"
-          onClick={() => onNext}
+          onClick={onNext}
         />
       </div>
     </div>
@@ -138,7 +138,7 @@ const BeforeConfirmationCard = ({
           fontColor="text-white"
           isBorder={false}
           title="Request"
-          onClick={() => onNext}
+          onClick={onNext}
         />
         <Button
           type="large"
@@ -146,7 +146,7 @@ const BeforeConfirmationCard = ({
           fontColor="text-[#222]"
           isBorder={false}
           title="Confirm"
-          onClick={() => onNext}
+          onClick={onNext}
         />
       </div>
     </div>

--- a/src/components/Document/DocumentCard.tsx
+++ b/src/components/Document/DocumentCard.tsx
@@ -1,0 +1,367 @@
+import { DocumentInfo } from '@/types/api/document';
+import Button from '@/components/Common/Button';
+import ArrowrightIcon from '@/assets/icons/Chevron.svg?react';
+import TalkBallonIcon from '@/assets/icons/TalkBalloon.svg?react';
+import TalkBallonIconGrey from '@/assets/icons/TalkBalloonGrey.svg?react';
+import FolderIcon from '@/assets/icons/FolderIcon.svg?react';
+import DownloadIcon from '@/assets/icons/DownloadIcon.svg?react';
+import CheckIconGreen from '@/assets/icons/CheckIconGreen.svg?react';
+import WriteIcon from '@/assets/icons/WriteIcon.svg?react';
+
+const enum DocumentStatus {
+  TEMPORARY_SAVE = 'TEMPORARY_SAVE',
+  SUBMITTED = 'SUBMITTED',
+  BEFORE_CONFIRMATION = 'BEFORE_CONFIRMATION',
+  REQUEST = 'REQUEST',
+  CONFIRMATION = 'CONFIRMATION',
+}
+
+type DocumentCardProps = {
+  document: DocumentInfo;
+  title: string;
+  onNext: () => void;
+};
+
+const TemporarySaveCard = ({
+  title,
+  onNext,
+}: {
+  title: string;
+  onNext: () => void;
+}) => {
+  return (
+    <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
+      <div className="self-stretch rounded-t-[1.125rem] bg-[#fef387] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
+        <div className="flex items-center justify-start relative ">
+          Check my Work Permit Form
+        </div>
+        <div className="w-1.5 absolute !m-0 top-[0.4rem] left-[8rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
+        <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
+          <div className="absolute w-full h-full top-0 righ-0 bottom-0 left-0" />
+          <ArrowrightIcon />
+        </div>
+      </div>
+      <div className="self-stretch flex flex-col items-start px-4 gap-4 body-1">
+        <div className="self-stretch border-b border-[#dcdcdc] h-10 flex items-center justify-center pl-2 pb-2 gap-4">
+          <div className="flex-1 flex items-center justify-start">
+            <div className="relative head-3">{title}</div>
+          </div>
+          <div className="overflow-hidden flex items-center justify-center p-2">
+            <TalkBallonIcon />
+          </div>
+        </div>
+
+        <div className="self-stretch flex items-center justify-center px-3 text-[#656565] caption-1">
+          <div className="flex-1 relative">
+            <p className="m-0">
+              You can request the employer to complete the part-time employment
+              permit form by clicking Submit. After the request is made, editing
+              will no longer be possible.
+            </p>
+            <div>&nbsp;</div>
+            <p className="m-0 text-[#FF6F61]">
+              * Please carefully review the information to ensure its accuracy.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="flex self-stretch items-center justify-center p-4 gap-1 text-[#464646]">
+        <Button
+          type="large"
+          bgColor="bg-[#f4f4f9]"
+          fontColor="text-[#222]"
+          isBorder={false}
+          title="Edit"
+          onClick={() => onNext}
+        />
+        <Button
+          type="large"
+          bgColor="bg-[#fef387]"
+          fontColor="text-[#222]"
+          isBorder={false}
+          title="Submit"
+          onClick={() => onNext}
+        />
+      </div>
+    </div>
+  );
+};
+
+const BeforeConfirmationCard = ({
+  title,
+  onNext,
+}: {
+  title: string;
+  onNext: () => void;
+}) => {
+  return (
+    <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
+      <div className="self-stretch rounded-t-[1.125rem] bg-[#fef387] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
+        <div className="flex items-center justify-start relative ">
+          Check my Work Permit Form
+        </div>
+        <div className="w-1.5 absolute !m-0 top-[0.4rem] left-[8rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
+        <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
+          <div className="absolute w-full h-full top-0 righ-0 bottom-0 left-0" />
+          <ArrowrightIcon />
+        </div>
+      </div>
+      <div className="self-stretch flex flex-col items-start px-4 gap-4 body-1">
+        <div className="self-stretch border-b border-[#dcdcdc] h-10 flex items-center justify-center pl-2 pb-2 gap-4">
+          <div className="flex-1 flex items-center justify-start">
+            <div className="relative head-3">{title}</div>
+          </div>
+          <div className="overflow-hidden flex items-center justify-center p-2">
+            <TalkBallonIcon />
+          </div>
+        </div>
+
+        <div className="self-stretch flex items-center justify-center px-3 text-[#656565] caption-1">
+          <div className="flex-1 relative">
+            <p className="m-0">
+              The employer has completed the part-time employment permit form.
+              Please review the content and if there are any issues, submit a
+              Request. If everything is fine, complete the process by selecting
+              Confirm.
+            </p>
+            <div>&nbsp;</div>
+            <p className="m-0 text-[#FF6F61]">
+              * Please note that after confirming, no further edits can be made
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="flex self-stretch items-center justify-center p-4 gap-1 text-[#464646]">
+        <Button
+          type="large"
+          bgColor="bg-[#1e1926]"
+          fontColor="text-white"
+          isBorder={false}
+          title="Request"
+          onClick={() => onNext}
+        />
+        <Button
+          type="large"
+          bgColor="bg-[#fef387]"
+          fontColor="text-[#222]"
+          isBorder={false}
+          title="Confirm"
+          onClick={() => onNext}
+        />
+      </div>
+    </div>
+  );
+};
+
+const SubmittedCard = ({ title }: { title: string }) => {
+  return (
+    <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
+      <div className="self-stretch rounded-t-[1.125rem] bg-[#1e1926] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
+        <div className="flex items-center justify-start relative text-[#f4f4f9]">
+          Pending ...
+        </div>
+      </div>
+      <div className="self-stretch flex flex-col items-start px-4 gap-4 body-1">
+        <div className="self-stretch border-b border-[#dcdcdc] h-10 flex items-center justify-center pl-2 pb-2 gap-4">
+          <div className="flex-1 flex items-center justify-start">
+            <div className="relative head-3">{title}</div>
+          </div>
+          <div className="overflow-hidden flex items-center justify-center p-2">
+            <TalkBallonIcon />
+          </div>
+        </div>
+
+        <div className="self-stretch flex items-center justify-center px-3 text-[#656565] caption-1">
+          <div className="flex-1 relative">
+            <p className="m-0">
+              The employer is in the process of completing the part-time
+              employment permit form
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col w-full items-start justify-start py-2 px-4 text-[#464646]">
+        <div className="w-full rounded-3xl bg-[#f4f4f9] flex items-center justify-start border border-[#dcdcdc] px-4 py-2 pl-2.5">
+          <div className="flex items-center justify-start gap-2">
+            <div className="w-[1.375rem] h-[1.375rem] flex items-center justify-center rounded-full bg-[#1e1926]">
+              <TalkBallonIconGrey />
+            </div>
+            <div className="relative body-3 opacity-75">writing ...</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const RequestedCard = ({ title }: { title: string }) => {
+  return (
+    <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
+      <div className="self-stretch rounded-t-[1.125rem] bg-[#1e1926] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
+        <div className="flex items-center justify-start relative text-[#f4f4f9]">
+          Pending ...
+        </div>
+      </div>
+      <div className="self-stretch flex flex-col items-start px-4 gap-4 body-1">
+        <div className="self-stretch border-b border-[#dcdcdc] h-10 flex items-center justify-center pl-2 pb-2 gap-4">
+          <div className="flex-1 flex items-center justify-start">
+            <div className="relative head-3">{title}</div>
+          </div>
+          <div className="overflow-hidden flex items-center justify-center p-2">
+            <TalkBallonIcon />
+          </div>
+        </div>
+
+        <div className="self-stretch flex items-center justify-center px-3 text-[#656565] caption-1">
+          <div className="flex-1 relative">
+            <p className="m-0">
+              The employer is revising the document according to the requested
+              changes.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col w-full items-start justify-start py-2 px-4 text-[#464646]">
+        <div className="w-full rounded-3xl bg-[#f4f4f9] flex items-center justify-start border border-[#dcdcdc] px-4 py-2 pl-2.5">
+          <div className="flex items-center justify-start gap-2">
+            <div className="w-[1.375rem] h-[1.375rem] flex items-center justify-center rounded-full bg-[#1e1926]">
+              <TalkBallonIconGrey />
+            </div>
+            <div className="relative body-3 opacity-75">rewriting ...</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ConfirmationCard = ({
+  document,
+  title,
+  onDownload,
+}: {
+  title: string;
+  document: DocumentInfo;
+  onDownload: (url: string) => void;
+}) => {
+  return (
+    <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
+      <div className="self-stretch rounded-t-[1.125rem] bg-[#1e1926] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
+        <div className="flex items-center justify-start relative text-[#fef387]">
+          Your form is ready ! Check it out
+        </div>
+      </div>
+      <div className="self-stretch flex flex-col items-start px-4 gap-4 body-1">
+        <div className="self-stretch border-b border-[#dcdcdc] h-10 flex items-center justify-center pl-2 pb-2 gap-4">
+          <div className="flex-1 flex items-center justify-start">
+            <div className="relative head-3">{title}</div>
+          </div>
+          <div className="overflow-hidden flex items-center justify-center p-2">
+            {!document.pdf_url && !document.hwp_url && !document.word_url ? (
+              <WriteIcon />
+            ) : (
+              <CheckIconGreen />
+            )}
+          </div>
+        </div>
+
+        <div className="self-stretch flex items-center justify-center px-3 text-[#656565] caption-1">
+          <div className="flex-1 relative">
+            <p className="m-0">
+              The employer is in the process of completing the part-time
+              employment permit form
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 w-full items-start justify-start py-2 px-4 text-[#464646]">
+        {document.pdf_url && (
+          <div className="w-full rounded-3xl bg-[#f4f4f9] flex items-center justify-between border border-[#dcdcdc] px-4 py-2 pl-2.5">
+            <div className="flex items-center justify-start gap-2">
+              <div className="w-[1.375rem] h-[1.375rem] flex items-center justify-center rounded-full bg-[#1e1926]">
+                <FolderIcon />
+              </div>
+              <div className="relative body-3 opacity-75">
+                Pdf file download
+              </div>
+            </div>
+            <div onClick={() => onDownload(document.pdf_url as string)}>
+              <DownloadIcon />
+            </div>
+          </div>
+        )}
+        {document.word_url && (
+          <div className="w-full rounded-3xl bg-[#f4f4f9] flex items-center justify-between border border-[#dcdcdc] px-4 py-2 pl-2.5">
+            <div className="flex items-center justify-start gap-2">
+              <div className="w-[1.375rem] h-[1.375rem] flex items-center justify-center rounded-full bg-[#1e1926]">
+                <FolderIcon />
+              </div>
+              <div className="relative body-3 opacity-75">
+                word file download
+              </div>
+            </div>
+            <div onClick={() => onDownload(document.word_url as string)}>
+              <DownloadIcon />
+            </div>
+          </div>
+        )}
+        {document.hwp_url && (
+          <div className="w-full rounded-3xl bg-[#f4f4f9] flex items-center justify-between border border-[#dcdcdc] px-4 py-2 pl-2.5">
+            <div className="flex items-center justify-start gap-2">
+              <div className="w-[1.375rem] h-[1.375rem] flex items-center justify-center rounded-full bg-[#1e1926]">
+                <FolderIcon />
+              </div>
+              <div className="relative body-3 opacity-75">
+                smth file download
+              </div>
+            </div>
+            <div onClick={() => onDownload(document.hwp_url as string)}>
+              <DownloadIcon />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const DocumentCardDispenser = ({
+  document,
+  title,
+  onNext,
+}: DocumentCardProps) => {
+  const handleDownload = (url: string) => {
+    window.open(url, '_blank');
+  };
+  if (title === 'Integrated Application Form')
+    return (
+      <ConfirmationCard
+        title={title}
+        document={document}
+        onDownload={handleDownload}
+      />
+    );
+  switch (document.status) {
+    case DocumentStatus.TEMPORARY_SAVE:
+      return <TemporarySaveCard title={title} onNext={onNext} />;
+    case DocumentStatus.SUBMITTED:
+      return <SubmittedCard title={title} />;
+    case DocumentStatus.BEFORE_CONFIRMATION:
+      return <BeforeConfirmationCard title={title} onNext={onNext} />;
+    case DocumentStatus.REQUEST:
+      return <RequestedCard title={title} />;
+    case DocumentStatus.CONFIRMATION:
+      return (
+        <ConfirmationCard
+          title={title}
+          document={document}
+          onDownload={handleDownload}
+        />
+      );
+  }
+};
+
+export default DocumentCardDispenser;

--- a/src/components/Document/DocumentCardList.tsx
+++ b/src/components/Document/DocumentCardList.tsx
@@ -3,9 +3,9 @@ import {
   DocumentType,
   DocumentTypeInfo,
 } from '@/types/api/document';
-import DocumentCard from './DocumentCard';
 import AddIcon from '@/assets/icons/AddButton.svg?react';
 import { useNavigate } from 'react-router-dom';
+import DocumentCardDispenser from './DocumentCard';
 
 const DocumentCardList = ({
   documents,
@@ -14,6 +14,11 @@ const DocumentCardList = ({
 }) => {
   const navigate = useNavigate();
   const documentTypes = Object.values(DocumentType);
+  const handleOnNext = () => {
+    //추후 api 작성 시 완성
+    alert('onNext');
+  };
+
   const MakeDocumentButton = ({ title }: { title: string }) => {
     return (
       <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-start justify-start py-6 cursor-pointer text-left text-[#1e1926]">
@@ -32,10 +37,14 @@ const DocumentCardList = ({
   };
 
   return (
-    <div className="w-full px-6">
+    <div className="flex flex-col w-full px-6 gap-2">
       {documentTypes.map((property) =>
         documents[property] ? (
-          <DocumentCard document={documents[property]} />
+          <DocumentCardDispenser
+            document={documents[property]}
+            title={DocumentTypeInfo[property].name}
+            onNext={handleOnNext}
+          />
         ) : (
           <MakeDocumentButton title={DocumentTypeInfo[property].name} />
         ),

--- a/src/components/Document/DocumentCardList.tsx
+++ b/src/components/Document/DocumentCardList.tsx
@@ -1,0 +1,47 @@
+import {
+  DocumentsSummaryResponse,
+  DocumentType,
+  DocumentTypeInfo,
+} from '@/types/api/document';
+import DocumentCard from './DocumentCard';
+import AddIcon from '@/assets/icons/AddButton.svg?react';
+import { useNavigate } from 'react-router-dom';
+
+const DocumentCardList = ({
+  documents,
+}: {
+  documents: DocumentsSummaryResponse;
+}) => {
+  const navigate = useNavigate();
+  const documentTypes = Object.values(DocumentType);
+  const MakeDocumentButton = ({ title }: { title: string }) => {
+    return (
+      <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-start justify-start py-6 cursor-pointer text-left text-[#1e1926]">
+        <div className="self-stretch flex flex-col items-start justify-start px-4">
+          <div className="self-stretch flex flex-row items-center justify-center pl-2 gap-4">
+            <div className="flex-1 flex items-center justify-start">
+              <div className="relative head-3">{title}</div>
+            </div>
+            <div onClick={() => navigate('/write/application-form')}>
+              <AddIcon />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="w-full px-6">
+      {documentTypes.map((property) =>
+        documents[property] ? (
+          <DocumentCard document={documents[property]} />
+        ) : (
+          <MakeDocumentButton title={DocumentTypeInfo[property].name} />
+        ),
+      )}
+    </div>
+  );
+};
+
+export default DocumentCardList;

--- a/src/components/Document/DocumentCardList.tsx
+++ b/src/components/Document/DocumentCardList.tsx
@@ -1,39 +1,17 @@
-import {
-  DocumentsSummaryResponse,
-  DocumentType,
-  DocumentTypeInfo,
-} from '@/types/api/document';
-import AddIcon from '@/assets/icons/AddButton.svg?react';
-import { useNavigate } from 'react-router-dom';
+import { DocumentsSummaryResponse, DocumentType } from '@/types/api/document';
 import DocumentCardDispenser from './DocumentCard';
+import MakeDocumentButton from './MakeDocumentButton';
+import { DocumentTypeInfo } from '@/constants/documents';
 
 const DocumentCardList = ({
   documents,
 }: {
   documents: DocumentsSummaryResponse;
 }) => {
-  const navigate = useNavigate();
   const documentTypes = Object.values(DocumentType);
   const handleOnNext = () => {
     //추후 api 작성 시 완성
     alert('onNext');
-  };
-
-  const MakeDocumentButton = ({ title }: { title: string }) => {
-    return (
-      <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-start justify-start py-6 cursor-pointer text-left text-[#1e1926]">
-        <div className="self-stretch flex flex-col items-start justify-start px-4">
-          <div className="self-stretch flex flex-row items-center justify-center pl-2 gap-4">
-            <div className="flex-1 flex items-center justify-start">
-              <div className="relative head-3">{title}</div>
-            </div>
-            <div onClick={() => navigate('/write/application-form')}>
-              <AddIcon />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
   };
 
   return (

--- a/src/components/Document/MakeDocumentButton.tsx
+++ b/src/components/Document/MakeDocumentButton.tsx
@@ -1,0 +1,23 @@
+import AddIcon from '@/assets/icons/AddButton.svg?react';
+import { useNavigate } from 'react-router-dom';
+
+const MakeDocumentButton = ({ title }: { title: string }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-start justify-start py-6 cursor-pointer text-left text-[#1e1926]">
+      <div className="self-stretch flex flex-col items-start justify-start px-4">
+        <div className="self-stretch flex flex-row items-center justify-center pl-2 gap-4">
+          <div className="flex-1 flex items-center justify-start">
+            <div className="relative head-3">{title}</div>
+          </div>
+          <div onClick={() => navigate('/write/application-form')}>
+            <AddIcon />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MakeDocumentButton;

--- a/src/constants/documents.ts
+++ b/src/constants/documents.ts
@@ -1,0 +1,17 @@
+import { DocumentType } from '@/types/api/document';
+
+// 문서 타입별 정보를 담은 객체
+export const DocumentTypeInfo = {
+  [DocumentType.PART_TIME_PERMIT]: {
+    name: 'Part-Time Work Permit Form',
+    key: 'part_time_employment_permits',
+  },
+  [DocumentType.LABOR_CONTRACT]: {
+    name: 'Employment Contract',
+    key: 'standard_labor_contract',
+  },
+  [DocumentType.INTEGRATED_APPLICATION]: {
+    name: 'Integrated Application Form',
+    key: 'integrated_application',
+  },
+} as const;

--- a/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
+++ b/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
@@ -1,0 +1,53 @@
+import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
+import Button from '@/components/Common/Button';
+import BaseHeader from '@/components/Common/Header/BaseHeader';
+import DocumentCardList from '@/components/Document/DocumentCardList';
+import { DocumentsSummaryResponse } from '@/types/api/document';
+
+const mockDocumentsSummaryResponse: DocumentsSummaryResponse = {
+    part_time_employment_permits: {
+      id: 1001,
+      pdf_url: "https://example.com/permits/part_time_1001.pdf",
+      hwp_url: "https://example.com/permits/part_time_1001.hwp",
+      word_url: "https://example.com/permits/part_time_1001.docx",
+      status: "SUBMITTED"
+    },
+    standard_labor_contract: {
+      id: 2001,
+      pdf_url: "https://example.com/contracts/standard_2001.pdf",
+      hwp_url: "https://example.com/contracts/standard_2001.hwp",
+      word_url: "https://example.com/contracts/standard_2001.docx",
+      status: "CONFIRMATION"
+    },
+
+};
+
+const ApplicationDocumentsPage = () => {
+      {/*integrated_application: {
+      id: 3001,
+      pdf_url: "https://example.com/applications/integrated_3001.pdf",
+      hwp_url: "https://example.com/applications/integrated_3001.hwp",
+      word_url: "https://example.com/applications/integrated_3001.docx"
+    }*/}
+  return (
+    <div>
+      <BaseHeader
+        hasBackButton={true}
+        hasMenuButton={true}
+        title="Application Documents"
+      />
+      <DocumentCardList documents={mockDocumentsSummaryResponse} />
+      <BottomButtonPanel>
+        <Button
+          type="large"
+          bgColor="bg-[#F4F4F9]"
+          fontColor="text-[#bdbdbd]"
+          isBorder={false}
+          title="Next"
+        />
+      </BottomButtonPanel>
+    </div>
+  );
+};
+
+export default ApplicationDocumentsPage;

--- a/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
+++ b/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
@@ -10,16 +10,21 @@ const mockDocumentsSummaryResponse: DocumentsSummaryResponse = {
       pdf_url: "https://example.com/permits/part_time_1001.pdf",
       hwp_url: "https://example.com/permits/part_time_1001.hwp",
       word_url: "https://example.com/permits/part_time_1001.docx",
-      status: "SUBMITTED"
+      status: "TEMPORARY_SAVE"
     },
     standard_labor_contract: {
       id: 2001,
       pdf_url: "https://example.com/contracts/standard_2001.pdf",
       hwp_url: "https://example.com/contracts/standard_2001.hwp",
       word_url: "https://example.com/contracts/standard_2001.docx",
-      status: "CONFIRMATION"
+      status: "BEFORE_CONFIRMATION"
     },
-
+    integrated_application: {
+      id: 3001,
+      pdf_url: "https://example.com/applications/integrated_3001.pdf",
+      hwp_url: "https://example.com/applications/integrated_3001.hwp",
+      word_url: "https://example.com/applications/integrated_3001.docx"
+    }
 };
 
 const ApplicationDocumentsPage = () => {

--- a/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
+++ b/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
@@ -19,12 +19,6 @@ const mockDocumentsSummaryResponse: DocumentsSummaryResponse = {
       word_url: "https://example.com/contracts/standard_2001.docx",
       status: "BEFORE_CONFIRMATION"
     },
-    integrated_application: {
-      id: 3001,
-      pdf_url: "https://example.com/applications/integrated_3001.pdf",
-      hwp_url: "https://example.com/applications/integrated_3001.hwp",
-      word_url: "https://example.com/applications/integrated_3001.docx"
-    }
 };
 
 const ApplicationDocumentsPage = () => {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import HomePage from '@/pages/Home/HomePage';
-import InformationPage from './pages/Information/InformationPage';
-import ApplicationDocumentsPage from './pages/ApplicationDocuments/ApplicationDocumentsPage';
+import InformationPage from '@/pages/Information/InformationPage';
+import ApplicationDocumentsPage from '@/pages/ApplicationDocuments/ApplicationDocumentsPage';
 
 const Router = () => {
   return (

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import HomePage from '@/pages/Home/HomePage';
 import InformationPage from './pages/Information/InformationPage';
+import ApplicationDocumentsPage from './pages/ApplicationDocuments/ApplicationDocumentsPage';
 
 const Router = () => {
   return (
@@ -8,6 +9,10 @@ const Router = () => {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/information" element={<InformationPage />} />
+        <Route
+          path="/application-documents"
+          element={<ApplicationDocumentsPage />}
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/src/types/api/document.ts
+++ b/src/types/api/document.ts
@@ -1,0 +1,49 @@
+export type DocumentStatus =
+  | 'TEMPORARY_SAVE'
+  | 'SUBMITTED'
+  | 'BEFORE_CONFIRMATION'
+  | 'REQUEST'
+  | 'CONFIRMATION';
+
+export type DocumentInfo = {
+  id: number;
+  pdf_url?: string;
+  hwp_url?: string;
+  word_url?: string;
+  status?: DocumentStatus;
+};
+
+export type IntegratedApplicationInfo = {
+  id: number;
+  pdf_url?: string;
+  hwp_url?: string;
+  word_url?: string;
+};
+
+export type DocumentsSummaryResponse = {
+  part_time_employment_permits?: DocumentInfo;
+  standard_labor_contract?: DocumentInfo;
+  integrated_application?: DocumentInfo;
+};
+
+export enum DocumentType {
+  PART_TIME_PERMIT = 'part_time_employment_permits',
+  LABOR_CONTRACT = 'standard_labor_contract',
+  INTEGRATED_APPLICATION = 'integrated_application',
+}
+
+// 문서 타입별 정보를 담은 객체
+export const DocumentTypeInfo = {
+  [DocumentType.PART_TIME_PERMIT]: {
+    name: 'Part-Time Work Permit Form',
+    key: 'part_time_employment_permits',
+  },
+  [DocumentType.LABOR_CONTRACT]: {
+    name: 'Employment Contract',
+    key: 'standard_labor_contract',
+  },
+  [DocumentType.INTEGRATED_APPLICATION]: {
+    name: 'Integrated Application Form',
+    key: 'integrated_application',
+  },
+} as const;

--- a/src/types/api/document.ts
+++ b/src/types/api/document.ts
@@ -31,19 +31,3 @@ export enum DocumentType {
   LABOR_CONTRACT = 'standard_labor_contract',
   INTEGRATED_APPLICATION = 'integrated_application',
 }
-
-// 문서 타입별 정보를 담은 객체
-export const DocumentTypeInfo = {
-  [DocumentType.PART_TIME_PERMIT]: {
-    name: 'Part-Time Work Permit Form',
-    key: 'part_time_employment_permits',
-  },
-  [DocumentType.LABOR_CONTRACT]: {
-    name: 'Employment Contract',
-    key: 'standard_labor_contract',
-  },
-  [DocumentType.INTEGRATED_APPLICATION]: {
-    name: 'Integrated Application Form',
-    key: 'integrated_application',
-  },
-} as const;


### PR DESCRIPTION
## Related issue 🛠

#24 

## Work Description ✏️

- 시간제 취업허가서, 근로계약서, 통합신청서 별로 생성 전, 임시 저장, 요청, 작성 완료, 승인 대기 상태 별 다른 카드 UI 적용
<img width="480" alt="스크린샷 2024-10-22 오후 8 04 06" src="https://github.com/user-attachments/assets/18cab6b4-7649-4bb9-8356-020081c9cbc6">
<img width="476" alt="스크린샷 2024-10-22 오후 8 15 51" src="https://github.com/user-attachments/assets/b76476dd-44f6-44a2-a5a7-7c701aa3a820">

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] API 연결

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
