### PR TITLE
[Feat/igw-37/48] - 고용주 버전 공고 상세 보기 페이지

### DIFF
--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -1,0 +1,13 @@
+import { api } from '.';
+
+// 4.4 (유학생/고용주) 공고 상세 조회하기
+export const getPostDetail = async (id: number) => {
+  const response = await api.post(`/api/v1/job-postings/${id}/details`);
+  return response.data;
+};
+
+// 4.13 (고용주) 공고 삭제하기
+export const deletePost = async (id: number) => {
+  const response = await api.delete(`/api/v1/owners/job-postings/${id}`);
+  return response.data;
+};

--- a/src/components/Employer/PostDetail/EmployerPostDeleteBottomSheet.tsx
+++ b/src/components/Employer/PostDetail/EmployerPostDeleteBottomSheet.tsx
@@ -1,0 +1,56 @@
+import BottomSheetLayout from '@/components/Common/BottomSheetLayout';
+import Button from '@/components/Common/Button';
+import { buttonTypeKeys } from '@/constants/components';
+
+type EmployerPostDeleteBottomSheetType = {
+  isShowBottomsheet: boolean;
+  setIsShowBottomSheet: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const EmployerPostDeleteBottomSheet = ({
+  isShowBottomsheet,
+  setIsShowBottomSheet,
+}: EmployerPostDeleteBottomSheetType) => {
+  const onClickDelete = () => {
+    // TODO: 4.13 호출
+    // 고용주 공고 - 작성한 공고 조회 페이지로 이동하기
+  };
+
+  return (
+    <BottomSheetLayout
+      hasHandlebar={true}
+      isAvailableHidden={true}
+      isShowBottomsheet={isShowBottomsheet}
+      setIsShowBottomSheet={setIsShowBottomSheet}
+    >
+      <div className="w-full flex flex-col items-center text-center">
+        <h3 className="px-[1.625rem] pb-[0.75rem] head-2 text-[#1E1926]">
+          Delete Post
+        </h3>
+        <p className="px-[1.625rem] pb-[0.25rem] body-3 text-[#656565]">
+          Unable to recover after deletion.
+        </p>
+      </div>
+      <div className="w-full py-[3rem] flex flex-col gap-[0.5rem]">
+        <Button
+          type={buttonTypeKeys.LARGE}
+          bgColor="bg-[#FEF387]"
+          fontColor="text-[#1E1926]"
+          isBorder={false}
+          title="Delete Post"
+          onClick={onClickDelete}
+        />
+        <Button
+          type={buttonTypeKeys.LARGE}
+          bgColor="bg-[#F4F4F9]"
+          fontColor="text-[#BDBDBD]"
+          isBorder={false}
+          title="Cancel"
+          onClick={() => setIsShowBottomSheet(false)}
+        />
+      </div>
+    </BottomSheetLayout>
+  );
+};
+
+export default EmployerPostDeleteBottomSheet;

--- a/src/components/Employer/PostDetail/EmployerPostDetailButton.tsx
+++ b/src/components/Employer/PostDetail/EmployerPostDetailButton.tsx
@@ -1,0 +1,37 @@
+import Button from '@/components/Common/Button';
+import { buttonTypeKeys } from '@/constants/components';
+import { useState } from 'react';
+import EmployerPostDeleteBottomSheet from '@/components/Employer/PostDetail/EmployerPostDeleteBottomSheet';
+
+const EmployerPostDetailButton = () => {
+  const [isOpenDeleteBottomSheet, setIsOpenDeleteBottomSheet] =
+    useState<boolean>(false);
+  return (
+    <>
+      <footer className="fixed bottom-0 left-0 w-full flex gap-[0.5rem] pt-[0.75rem] px-[1.5rem] pb-[2.5rem] bg-white z-20">
+        <Button
+          type={buttonTypeKeys.BACK}
+          bgColor="bg-[#F4F4F9]"
+          fontColor="text-[#BDBDBD]"
+          isBorder={false}
+          title="Delete"
+          onClick={() => setIsOpenDeleteBottomSheet(true)}
+        />
+        <Button
+          type={buttonTypeKeys.CONTINUE}
+          bgColor="bg-[#FEF387]"
+          fontColor="text-[#1E1926]"
+          isBorder={false}
+          title="Edit"
+          // TODO: 고용주 - 공고 수정 - 1단계로 이동하기
+        />
+      </footer>
+      <EmployerPostDeleteBottomSheet
+        isShowBottomsheet={isOpenDeleteBottomSheet}
+        setIsShowBottomSheet={setIsOpenDeleteBottomSheet}
+      />
+    </>
+  );
+};
+
+export default EmployerPostDetailButton;

--- a/src/components/PostDetail/PostDetailTitle.tsx
+++ b/src/components/PostDetail/PostDetailTitle.tsx
@@ -40,7 +40,7 @@ const PostDetailTitle = ({ postDetailData }: PostDetailTitleProps) => {
           fontStyle="caption-1"
         />
         <Tag
-          value={postDetailData.tags.visa}
+          value={postDetailData.tags.visa.replace(/_/g, '-')}
           padding="0.375rem 0.75rem"
           isRounded={true}
           hasCheckIcon={false}

--- a/src/constants/postDetail.ts
+++ b/src/constants/postDetail.ts
@@ -1,5 +1,86 @@
+import { PostDetailItemType } from '@/types/postDetail/postDetailItem';
+
 export const enum PostDetailContentMenu {
   RECUITMENT = 'RECUITMENT',
   WORPLACE = 'WORPLACE',
   COMPANY = 'COMPANY',
 }
+
+// 더미데이터
+export const POST_DETAIL_DATA: PostDetailItemType = {
+  id: 1,
+  is_my_post: true,
+  is_book_marked: false,
+  company_name: 'Tech Solutions Inc.',
+  title: 'Part-time English Tutor',
+  icon_img_url: 'https://example.com/icon.png',
+  company_img_url_list: [
+    {
+      id: 1,
+      img_url: 'https://example.com/company1.png',
+    },
+    {
+      id: 2,
+      img_url: 'https://example.com/company2.png',
+    },
+    {
+      id: 3,
+      img_url: 'https://example.com/company3.png',
+    },
+  ],
+  tags: {
+    is_recruiting: true,
+    visa: 'D_2_7',
+    job_category: 'ENGLISH_KIDS_CAFE',
+  },
+  summaries: {
+    address: '123 Main St, Seoul',
+    houlry_rate: 15000,
+    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
+    work_days_per_week: 5,
+  },
+  recruitment_conditions: {
+    recruitment_dead_line: '2024-12-31',
+    education: 'BACHELOR',
+    number_of_recruits: 3,
+    visa: 'D_2_7',
+    gender: 'NONE',
+    preferred_conditions: 'Previous tutoring experience preferred',
+  },
+  detailed_overview:
+    'We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children.',
+  workplace_information: {
+    main_address: '123 Main St, Seoul',
+    detailed_address: '5th Floor, Room 501',
+    school_name: 'Seoul National University',
+    distance: 1.5,
+    latitude: 37.5665,
+    longitude: 126.978,
+  },
+  working_conditions: {
+    houlry_rate: 15000,
+    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
+    work_day_times: [
+      {
+        day_of_week: 'WEEKDAYS',
+        work_start_time: '14:00',
+        work_end_time: '18:00',
+      },
+      {
+        day_of_week: 'SATURDAY',
+        work_start_time: '10:00',
+        work_end_time: '14:00',
+      },
+    ],
+    job_category: 'ENGLISH_KIDS_CAFE',
+    employment_type: 'PARTTIME',
+  },
+  company_information: {
+    company_address: '123 Main St, Seoul',
+    representative_name: 'John Doe',
+    recruiter: 'Jane Smith',
+    contact: '+82 10-1234-5678',
+    email: 'recruiter@example.com',
+  },
+  created_at: '2024-10-22T12:00:00',
+};

--- a/src/hooks/api/usePost.ts
+++ b/src/hooks/api/usePost.ts
@@ -1,0 +1,23 @@
+import { deletePost, getPostDetail } from '@/api/post';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+// 4.4 (유학생/고용주) 공고 상세 조회하기 훅
+export const useGetPostDetail = (id: number) => {
+  return useQuery({ queryKey: ['post', id], queryFn: () => getPostDetail(id) });
+};
+
+// 4.13 (고용주) 공고 삭제하기 훅
+export const useDeletePost = () => {
+  const navigate = useNavigate();
+  return useMutation({
+    mutationFn: deletePost,
+    onSuccess: () => {
+      // TODO: 고용주 공고 - 작성한 공고 조회 페이지로 이동하기
+      navigate('/employer/post');
+    },
+    onError: (error) => {
+      console.error('공고 삭제하기 실패', error);
+    },
+  });
+};

--- a/src/pages/Employer/PostDetail/EmployerPostDetailPage.tsx
+++ b/src/pages/Employer/PostDetail/EmployerPostDetailPage.tsx
@@ -3,87 +3,8 @@ import EmployerPostDetailButton from '@/components/Employer/PostDetail/EmployerP
 import PostDetailCompanyImageList from '@/components/PostDetail/PostDetailCompanyImageList';
 import PostDetailContent from '@/components/PostDetail/PostDetailContent';
 import PostDetailTitle from '@/components/PostDetail/PostDetailTitle';
-import { PostDetailItemType } from '@/types/postDetail/postDetailItem';
+import { POST_DETAIL_DATA } from '@/constants/postDetail';
 import { useNavigate } from 'react-router-dom';
-
-// 더미데이터
-const POST_DETAIL_DATA: PostDetailItemType = {
-  id: 1,
-  is_my_post: true,
-  is_book_marked: false,
-  company_name: 'Tech Solutions Inc.',
-  title: 'Part-time English Tutor',
-  icon_img_url: 'https://example.com/icon.png',
-  company_img_url_list: [
-    {
-      id: 1,
-      img_url: 'https://example.com/company1.png',
-    },
-    {
-      id: 2,
-      img_url: 'https://example.com/company2.png',
-    },
-    {
-      id: 3,
-      img_url: 'https://example.com/company3.png',
-    },
-  ],
-  tags: {
-    is_recruiting: true,
-    visa: 'D_2_7',
-    job_category: 'ENGLISH_KIDS_CAFE',
-  },
-  summaries: {
-    address: '123 Main St, Seoul',
-    houlry_rate: 15000,
-    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
-    work_days_per_week: 5,
-  },
-  recruitment_conditions: {
-    recruitment_dead_line: '2024-12-31',
-    education: 'BACHELOR',
-    number_of_recruits: 3,
-    visa: 'D_2_7',
-    gender: 'NONE',
-    preferred_conditions: 'Previous tutoring experience preferred',
-  },
-  detailed_overview:
-    'We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children.',
-  workplace_information: {
-    main_address: '123 Main St, Seoul',
-    detailed_address: '5th Floor, Room 501',
-    school_name: 'Seoul National University',
-    distance: 1.5,
-    latitude: 37.5665,
-    longitude: 126.978,
-  },
-  working_conditions: {
-    houlry_rate: 15000,
-    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
-    work_day_times: [
-      {
-        day_of_week: 'WEEKDAYS',
-        work_start_time: '14:00',
-        work_end_time: '18:00',
-      },
-      {
-        day_of_week: 'SATURDAY',
-        work_start_time: '10:00',
-        work_end_time: '14:00',
-      },
-    ],
-    job_category: 'ENGLISH_KIDS_CAFE',
-    employment_type: 'PARTTIME',
-  },
-  company_information: {
-    company_address: '123 Main St, Seoul',
-    representative_name: 'John Doe',
-    recruiter: 'Jane Smith',
-    contact: '+82 10-1234-5678',
-    email: 'recruiter@example.com',
-  },
-  created_at: '2024-10-22T12:00:00',
-};
 
 const EmployerPostDetailPage = () => {
   const navigate = useNavigate();

--- a/src/pages/Employer/PostDetail/EmployerPostDetailPage.tsx
+++ b/src/pages/Employer/PostDetail/EmployerPostDetailPage.tsx
@@ -1,0 +1,109 @@
+import BaseHeader from '@/components/Common/Header/BaseHeader';
+import EmployerPostDetailButton from '@/components/Employer/PostDetail/EmployerPostDetailButton';
+import PostDetailCompanyImageList from '@/components/PostDetail/PostDetailCompanyImageList';
+import PostDetailContent from '@/components/PostDetail/PostDetailContent';
+import PostDetailTitle from '@/components/PostDetail/PostDetailTitle';
+import { PostDetailItemType } from '@/types/postDetail/postDetailItem';
+import { useNavigate } from 'react-router-dom';
+
+// 더미데이터
+const POST_DETAIL_DATA: PostDetailItemType = {
+  id: 1,
+  is_my_post: true,
+  is_book_marked: false,
+  company_name: 'Tech Solutions Inc.',
+  title: 'Part-time English Tutor',
+  icon_img_url: 'https://example.com/icon.png',
+  company_img_url_list: [
+    {
+      id: 1,
+      img_url: 'https://example.com/company1.png',
+    },
+    {
+      id: 2,
+      img_url: 'https://example.com/company2.png',
+    },
+    {
+      id: 3,
+      img_url: 'https://example.com/company3.png',
+    },
+  ],
+  tags: {
+    is_recruiting: true,
+    visa: 'D_2_7',
+    job_category: 'ENGLISH_KIDS_CAFE',
+  },
+  summaries: {
+    address: '123 Main St, Seoul',
+    houlry_rate: 15000,
+    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
+    work_days_per_week: 5,
+  },
+  recruitment_conditions: {
+    recruitment_dead_line: '2024-12-31',
+    education: 'BACHELOR',
+    number_of_recruits: 3,
+    visa: 'D_2_7',
+    gender: 'NONE',
+    preferred_conditions: 'Previous tutoring experience preferred',
+  },
+  detailed_overview:
+    'We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children.',
+  workplace_information: {
+    main_address: '123 Main St, Seoul',
+    detailed_address: '5th Floor, Room 501',
+    school_name: 'Seoul National University',
+    distance: 1.5,
+    latitude: 37.5665,
+    longitude: 126.978,
+  },
+  working_conditions: {
+    houlry_rate: 15000,
+    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
+    work_day_times: [
+      {
+        day_of_week: 'WEEKDAYS',
+        work_start_time: '14:00',
+        work_end_time: '18:00',
+      },
+      {
+        day_of_week: 'SATURDAY',
+        work_start_time: '10:00',
+        work_end_time: '14:00',
+      },
+    ],
+    job_category: 'ENGLISH_KIDS_CAFE',
+    employment_type: 'PARTTIME',
+  },
+  company_information: {
+    company_address: '123 Main St, Seoul',
+    representative_name: 'John Doe',
+    recruiter: 'Jane Smith',
+    contact: '+82 10-1234-5678',
+    email: 'recruiter@example.com',
+  },
+  created_at: '2024-10-22T12:00:00',
+};
+
+const EmployerPostDetailPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <BaseHeader
+        hasBackButton={true}
+        onClickBackButton={() => navigate(-1)}
+        hasMenuButton={false}
+        title="Detail"
+      />
+      <PostDetailCompanyImageList
+        companyImageData={POST_DETAIL_DATA.company_img_url_list}
+      />
+      <PostDetailTitle postDetailData={POST_DETAIL_DATA} />
+      <PostDetailContent postDetailData={POST_DETAIL_DATA} />
+      <EmployerPostDetailButton />
+    </>
+  );
+};
+
+export default EmployerPostDetailPage;

--- a/src/pages/PostDetail/PostDetailPage.tsx
+++ b/src/pages/PostDetail/PostDetailPage.tsx
@@ -3,87 +3,8 @@ import PostDetailApplyButton from '@/components/PostDetail/PostDetailApplyButton
 import PostDetailCompanyImageList from '@/components/PostDetail/PostDetailCompanyImageList';
 import PostDetailContent from '@/components/PostDetail/PostDetailContent';
 import PostDetailTitle from '@/components/PostDetail/PostDetailTitle';
-import { PostDetailItemType } from '@/types/postDetail/postDetailItem';
+import { POST_DETAIL_DATA } from '@/constants/postDetail';
 import { useNavigate } from 'react-router-dom';
-
-// 더미데이터
-const POST_DETAIL_DATA: PostDetailItemType = {
-  id: 1,
-  is_my_post: true,
-  is_book_marked: false,
-  company_name: 'Tech Solutions Inc.',
-  title: 'Part-time English Tutor',
-  icon_img_url: 'https://example.com/icon.png',
-  company_img_url_list: [
-    {
-      id: 1,
-      img_url: 'https://example.com/company1.png',
-    },
-    {
-      id: 2,
-      img_url: 'https://example.com/company2.png',
-    },
-    {
-      id: 3,
-      img_url: 'https://example.com/company3.png',
-    },
-  ],
-  tags: {
-    is_recruiting: true,
-    visa: 'D_2_7',
-    job_category: 'ENGLISH_KIDS_CAFE',
-  },
-  summaries: {
-    address: '123 Main St, Seoul',
-    houlry_rate: 15000,
-    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
-    work_days_per_week: 5,
-  },
-  recruitment_conditions: {
-    recruitment_dead_line: '2024-12-31',
-    education: 'BACHELOR',
-    number_of_recruits: 3,
-    visa: 'D_2_7',
-    gender: 'NONE',
-    preferred_conditions: 'Previous tutoring experience preferred',
-  },
-  detailed_overview:
-    'We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children. We are looking for a part-time English tutor for a kids cafe. The role requires providing fun and interactive English lessons for young children.',
-  workplace_information: {
-    main_address: '123 Main St, Seoul',
-    detailed_address: '5th Floor, Room 501',
-    school_name: 'Seoul National University',
-    distance: 1.5,
-    latitude: 37.5665,
-    longitude: 126.978,
-  },
-  working_conditions: {
-    houlry_rate: 15000,
-    work_period: 'ONE_MONTH_TO_THREE_MONTHS',
-    work_day_times: [
-      {
-        day_of_week: 'WEEKDAYS',
-        work_start_time: '14:00',
-        work_end_time: '18:00',
-      },
-      {
-        day_of_week: 'SATURDAY',
-        work_start_time: '10:00',
-        work_end_time: '14:00',
-      },
-    ],
-    job_category: 'ENGLISH_KIDS_CAFE',
-    employment_type: 'PARTTIME',
-  },
-  company_information: {
-    company_address: '123 Main St, Seoul',
-    representative_name: 'John Doe',
-    recruiter: 'Jane Smith',
-    contact: '+82 10-1234-5678',
-    email: 'recruiter@example.com',
-  },
-  created_at: '2024-10-22T12:00:00',
-};
 
 const PostDetailPage = () => {
   const navigate = useNavigate();

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -19,6 +19,7 @@ import ApplicationPage from '@/pages/Application/ApplicationPage';
 import WriteDocumentsPage from '@/pages/WriteDocuments/WriteDocumentsPage';
 import ApplicationDetailPage from '@/pages/ApplicationDetail/ApplicationDetailPage';
 import ApplicationResultPage from '@/pages/ApplicationResult/ApplicationResultPage';
+import EmployerPostDetailPage from '@/pages/Employer/PostDetail/EmployerPostDetailPage';
 
 const Layout = () => {
   const location = useLocation();
@@ -62,7 +63,10 @@ const Router = () => {
 
           <Route path="/post/:id" element={<PostDetailPage />} />
           <Route path="/post/apply/:id" element={<PostApplyPage />} />
-
+          <Route
+            path="/employer/post/:id"
+            element={<EmployerPostDetailPage />}
+          />
           <Route path="/write-documents" element={<WriteDocumentsPage />} />
 
           <Route path="/application" element={<ApplicationPage />} />


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #48

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 고용주 버전 공고 상세 보기 페이지 퍼블리싱 및 관련 api 정의하기

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Task1

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

### 구현 결과


https://github.com/user-attachments/assets/27fdd8fe-4c3d-4b42-8d60-c802c21d76b9


### 고용주 페이지 개발 관련

pages > Employer 폴더 > ~ 페이지 폴더 

components > Employer 폴더 > ~ 페이지 폴더 


router path는 앞에 /employer를 일단 붙여뒀어요! 

예를 들어 고용주 공고 상세 페이지는 /employer/post/:id 로 했습니다! 또 좋은 의견 있으시면 코멘트 남겨주세요~