### PR TITLE
[feat/IGW-45/66] 근로일 및 근로일별 근로시간 BottomSheet 구현

### DIFF
--- a/src/assets/icons/DownArrowIcon.tsx
+++ b/src/assets/icons/DownArrowIcon.tsx
@@ -2,20 +2,20 @@ type Props = {
   isMarked: boolean;
 };
 
-const ArrowIcon = ({ isMarked }: Props) => {
+const DownArrowIcon = ({ isMarked }: Props) => {
   return (
     <svg
-      width="20"
-      height="20"
-      viewBox="0 0 20 20"
+      width="19"
+      height="18"
+      viewBox="0 0 19 18"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <g id="Iconography / Metaphor / ArrowUp">
+      <g id="Iconography">
         <path
           id="Path 5"
-          d="M2.91667 12.9167L10 5.83333L17.0833 12.9167"
-          stroke={isMarked ? '#1E1926' : '#BDBDBD'}
+          d="M15.875 6.375L9.5 12.75L3.125 6.375"
+          stroke={isMarked ? '#695F96' : '#BDBDBD'}
           strokeWidth="1.2"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -25,4 +25,4 @@ const ArrowIcon = ({ isMarked }: Props) => {
   );
 };
 
-export default ArrowIcon;
+export default DownArrowIcon;

--- a/src/components/Common/TimePicker.tsx
+++ b/src/components/Common/TimePicker.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import DownArrowIcon from '@/assets/icons/DownArrowIcon.tsx';
+import { HOUR_LIST, MINUTE_LIST } from '@/constants/time';
+
+type TimePickerProps = {
+  isDisabled: boolean;
+  onChangeTime: (time: string) => void;
+};
+
+const TimePicker = ({ isDisabled, onChangeTime }: TimePickerProps) => {
+  const [time, setTime] = useState({ hour: '00', minute: '00' });
+
+  const handleTimeChange = (field: 'hour' | 'minute', value: string) => {
+    if (isDisabled) return;
+    setTime((prev) => ({ ...prev, [field]: value }));
+    onChangeTime(`${time.hour}:${time.minute}`);
+  };
+  return (
+    <div
+      className={`w-full flex justify-between items-center border  ${isDisabled ? 'border-[#EAE9F6] text-[#BDBDBD]' : 'border-gray-300'} rounded-lg px-[1rem] py-[0.5rem]`}
+    >
+      <div>
+        <select
+          className="appearance-none rounded-l-lg focus:outline-none"
+          value={time.hour}
+          onChange={(e) => handleTimeChange('hour', e.target.value)}
+          disabled={isDisabled}
+        >
+          {HOUR_LIST.map((hour) => (
+            <option key={hour} value={hour}>
+              {hour}
+            </option>
+          ))}
+        </select>
+        <span className="px-1">:</span>
+        <select
+          className="appearance-none rounded-r-lg focus:outline-none"
+          value={time.minute}
+          onChange={(e) => handleTimeChange('minute', e.target.value)}
+          disabled={isDisabled}
+        >
+          {MINUTE_LIST.map((minute) => (
+            <option key={minute} value={minute}>
+              {minute}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="">
+        <DownArrowIcon isMarked={!isDisabled} />
+      </div>
+    </div>
+  );
+};
+
+export default TimePicker;

--- a/src/components/Common/WorkDayTimeBottomSheet.tsx
+++ b/src/components/Common/WorkDayTimeBottomSheet.tsx
@@ -1,0 +1,164 @@
+import BottomSheetLayout from '@/components/Common/BottomSheetLayout';
+import Button from '@/components/Common/Button';
+import { buttonTypeKeys } from '@/constants/components';
+import { useState } from 'react';
+import TimePicker from '@/components/Common/TimePicker';
+
+// TODO: 나중에 constant로 분리해주세요!
+const DAYS = {
+  ['월요일']: 'MONDAY',
+  ['화요일']: 'TUESDAY',
+  ['수요일']: 'WEDNESDAY',
+  ['목요일']: 'THURSDAY',
+  ['금요일']: 'FRIDAY',
+  ['토요일']: 'SATURDAY',
+  ['일요일']: 'SUNDAY',
+} as const;
+
+type DayType = (typeof DAYS)[keyof typeof DAYS];
+
+// api에게 보낼 데이터 형식
+type WorkDayTimeItemType = {
+  day_of_week: DayType | 'NEGOTIABLE';
+  work_start_time: string | null;
+  work_end_time: string | null;
+};
+
+const WorkDayTimeBottomSheet = () => {
+  const [isShowBottomsheet, setisShowBottomsheet] = useState<boolean>(true);
+
+  const [isCheckAllWeek, setIsCheckAllWeek] = useState<boolean>(false);
+  const [isCheckAllTime, setIsCheckAllTime] = useState<boolean>(false);
+
+  const [dayOfWeek, setDayOfWeek] = useState<DayType[]>([]);
+  const [workStartTime, setWorkStartTime] = useState<string | null>(null);
+  const [workEndTime, setWorkEndTime] = useState<string | null>(null);
+
+  const onClickDayOfWeek = (day: DayType) => {
+    if (dayOfWeek.includes(day)) {
+      setDayOfWeek([...dayOfWeek.filter((value) => value !== day)]);
+    } else {
+      setDayOfWeek([...dayOfWeek, day]);
+      setIsCheckAllWeek(false);
+    }
+  };
+
+  const onClickCheckAllWeek = () => {
+    if (!isCheckAllWeek) setDayOfWeek([]);
+    setIsCheckAllWeek(!isCheckAllWeek);
+  };
+
+  const isAvailableSubmit = () => {
+    if (
+      (dayOfWeek.length || isCheckAllWeek) &&
+      ((workStartTime && workEndTime) || isCheckAllTime)
+    )
+      return true;
+    return false;
+  };
+
+  const onClickSubmit = () => {
+    if (!isAvailableSubmit()) return;
+
+    if (isCheckAllWeek) {
+      const result: WorkDayTimeItemType[] = [
+        {
+          day_of_week: 'NEGOTIABLE',
+          work_start_time: isCheckAllTime ? null : workStartTime,
+          work_end_time: isCheckAllTime ? null : workEndTime,
+        },
+      ];
+
+      console.log(result); // TODO: API에 보낼 형식 맞춰놨쓔!
+    } else {
+      const result: WorkDayTimeItemType[] = dayOfWeek.map((day) => {
+        return {
+          day_of_week: DAYS[day as keyof typeof DAYS],
+          work_start_time: isCheckAllTime ? null : workStartTime,
+          work_end_time: isCheckAllTime ? null : workEndTime,
+        };
+      });
+
+      console.log(result); // TODO: API에 보낼 형식 맞춰놨쓔!
+    }
+    setisShowBottomsheet(false);
+  };
+
+  return (
+    <BottomSheetLayout
+      hasHandlebar={true}
+      isAvailableHidden={true}
+      isShowBottomsheet={isShowBottomsheet}
+    >
+      <div className="w-full">
+        <div className="w-full py-[0.75rem] px-[3.125rem] flex flex-col items-center gap-[0.75rem]">
+          <h3 className="head-2 text-[#1E1926]">근로일 및 근로일별 근로시간</h3>
+          <p className="body-3 text-[#656565]">
+            원하는 근무 시간을 추가해주세요.
+          </p>
+        </div>
+        <div className="w-full mb-[1rem] px-[1.5rem] flex flex-col gap-[0.5rem]">
+          <div>
+            <div className="w-full flex justify-between items-center">
+              <h5 className="px-[0.25rem] py-[0.375rem] text-[#1E1926] body-3">
+                근무일자 <span className="text-[#EE4700]">*</span>
+              </h5>
+              <div className="flex gap-[0.5rem] items-center py-[0.25rem]">
+                <button
+                  className={`w-[1rem] h-[1rem] border  border-[#F4F4F9] ${isCheckAllWeek && 'bg-[#FEF387]'}`}
+                  onClick={onClickCheckAllWeek}
+                ></button>
+                <p className="body-3 text-[#656565]">요일무관</p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-[0.5rem] w-full">
+              {Object.keys(DAYS).map((value, index) => (
+                <button
+                  className={`py-[0.375rem] px-[0.875rem] body-3 border border-[#EFEFEF] rounded-[1.125rem] ${dayOfWeek.includes(value as DayType) ? 'bg-[#FEF387]' : 'bg-white'}`}
+                  key={`${value}_${index}`}
+                  onClick={() => onClickDayOfWeek(value as DayType)}
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <div className="w-full flex justify-between items-center">
+              <h5 className="px-[0.25rem] py-[0.375rem] text-[#1E1926] body-3">
+                근무시간 <span className="text-[#EE4700]">*</span>
+              </h5>
+              <div className="flex gap-[0.5rem] items-center py-[0.25rem]">
+                <button
+                  className={`w-[1rem] h-[1rem] border  border-[#F4F4F9] ${isCheckAllTime && 'bg-[#FEF387]'}`}
+                  onClick={() => setIsCheckAllTime(!isCheckAllTime)}
+                ></button>
+                <p className="body-3 text-[#656565]">시간무관</p>
+              </div>
+            </div>
+            <div className="flex gap-[0.25rem] w-full ">
+              <TimePicker
+                isDisabled={!dayOfWeek.length && isCheckAllTime}
+                onChangeTime={setWorkStartTime}
+              />
+              <TimePicker
+                isDisabled={!dayOfWeek.length && isCheckAllTime}
+                onChangeTime={setWorkEndTime}
+              />
+            </div>
+          </div>
+        </div>
+        <Button
+          type={buttonTypeKeys.LARGE}
+          bgColor={isAvailableSubmit() ? `bg-[#FEF387]` : `bg-[#F4F4F9]`}
+          fontColor={isAvailableSubmit() ? `text-[#1E1926]` : `text-[#BDBDBD]`}
+          isBorder={false}
+          title={'추가하기'}
+          onClick={onClickSubmit}
+        />
+      </div>
+    </BottomSheetLayout>
+  );
+};
+
+export default WorkDayTimeBottomSheet;

--- a/src/components/Common/WorkDayTimeWithRestBottomSheet.tsx
+++ b/src/components/Common/WorkDayTimeWithRestBottomSheet.tsx
@@ -1,0 +1,149 @@
+import BottomSheetLayout from '@/components/Common/BottomSheetLayout';
+import Button from '@/components/Common/Button';
+import { buttonTypeKeys } from '@/constants/components';
+import { useState } from 'react';
+import TimePicker from '@/components/Common/TimePicker';
+
+// TODO: 나중에 constant로 분리해주세요!
+const DAYS = {
+  ['월요일']: 'MONDAY',
+  ['화요일']: 'TUESDAY',
+  ['수요일']: 'WEDNESDAY',
+  ['목요일']: 'THURSDAY',
+  ['금요일']: 'FRIDAY',
+  ['토요일']: 'SATURDAY',
+  ['일요일']: 'SUNDAY',
+} as const;
+
+type DayType = (typeof DAYS)[keyof typeof DAYS];
+
+// api에게 보낼 데이터 형식
+type WorkDayTimeItemType = {
+  day_of_week: DayType;
+  work_start_time: string;
+  work_end_time: string;
+  break_start_time: string;
+  break_end_time: string;
+};
+
+const WorkDayTimeWithRestBottomSheet = () => {
+  const [isShowBottomsheet, setisShowBottomsheet] = useState<boolean>(true);
+
+  const [dayOfWeek, setDayOfWeek] = useState<DayType[]>([]);
+  const [workStartTime, setWorkStartTime] = useState<string | null>(null);
+  const [workEndTime, setWorkEndTime] = useState<string | null>(null);
+  const [breakStartTime, setBreakStartTime] = useState<string | null>(null);
+  const [breakEndTime, setBreakEndTime] = useState<string | null>(null);
+
+  const onClickDayOfWeek = (day: DayType) => {
+    if (dayOfWeek.includes(day)) {
+      setDayOfWeek([...dayOfWeek.filter((value) => value !== day)]);
+    } else {
+      setDayOfWeek([...dayOfWeek, day]);
+    }
+  };
+
+  const isAvailableSubmit = () => {
+    if (
+      dayOfWeek.length &&
+      workStartTime &&
+      workEndTime &&
+      breakStartTime &&
+      breakEndTime
+    )
+      return true;
+    return false;
+  };
+
+  const onClickSubmit = () => {
+    if (!isAvailableSubmit()) return;
+
+    const result: WorkDayTimeItemType[] = dayOfWeek.map((day) => {
+      return {
+        day_of_week: DAYS[day as keyof typeof DAYS],
+        work_start_time: workStartTime!,
+        work_end_time: workEndTime!,
+        break_start_time: breakStartTime!,
+        break_end_time: breakEndTime!,
+      };
+    });
+
+    console.log(result); // TODO: API에 보낼 형식 맞춰놨쓔!
+    setisShowBottomsheet(false);
+  };
+
+  return (
+    <BottomSheetLayout
+      hasHandlebar={true}
+      isAvailableHidden={true}
+      isShowBottomsheet={isShowBottomsheet}
+    >
+      <div className="w-full">
+        <div className="w-full py-[0.75rem] px-[3.125rem] flex flex-col items-center gap-[0.75rem]">
+          <h3 className="head-2 text-[#1E1926]">근로일 및 근로일별 근로시간</h3>
+          <p className="body-3 text-[#656565]">
+            원하는 근무 시간을 추가해주세요.
+          </p>
+        </div>
+        <div className="w-full mb-[1rem] px-[1.5rem] flex flex-col gap-[0.5rem]">
+          <div>
+            <h5 className="px-[0.25rem] py-[0.375rem] text-[#1E1926] body-3">
+              근무일자 <span className="text-[#EE4700]">*</span>
+            </h5>
+            <div className="flex flex-wrap gap-[0.5rem] w-full">
+              {Object.keys(DAYS).map((value, index) => (
+                <button
+                  className={`py-[0.375rem] px-[0.875rem] body-3 border border-[#EFEFEF] rounded-[1.125rem] ${dayOfWeek.includes(value as DayType) ? 'bg-[#FEF387]' : 'bg-white'}`}
+                  key={`${value}_${index}`}
+                  onClick={() => onClickDayOfWeek(value as DayType)}
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <h5 className="px-[0.25rem] py-[0.375rem] text-[#1E1926] body-3">
+              근무시간 <span className="text-[#EE4700]">*</span>
+            </h5>
+            <div className="flex gap-[0.25rem] w-full ">
+              <TimePicker
+                isDisabled={!dayOfWeek.length}
+                onChangeTime={setWorkStartTime}
+              />
+              <TimePicker
+                isDisabled={!dayOfWeek.length}
+                onChangeTime={setWorkEndTime}
+              />
+            </div>
+          </div>
+          <div>
+            <h5 className="px-[0.25rem] py-[0.375rem] text-[#1E1926] body-3">
+              휴게시간 <span className="text-[#EE4700]">*</span>
+            </h5>
+            <div className="flex gap-[0.25rem] w-full ">
+              <TimePicker
+                isDisabled={!dayOfWeek.length}
+                onChangeTime={setBreakStartTime}
+              />
+              <TimePicker
+                isDisabled={!dayOfWeek.length}
+                onChangeTime={setBreakEndTime}
+              />
+            </div>
+          </div>
+        </div>
+        <Button
+          type={buttonTypeKeys.LARGE}
+          bgColor={isAvailableSubmit() ? `bg-[#FEF387]` : `bg-[#F4F4F9]`}
+          fontColor={isAvailableSubmit() ? `text-[#1E1926]` : `text-[#BDBDBD]`}
+          isBorder={false}
+          title={'추가하기'}
+          onClick={onClickSubmit}
+        />
+      </div>
+    </BottomSheetLayout>
+  );
+};
+
+export default WorkDayTimeWithRestBottomSheet;

--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -1,0 +1,6 @@
+export const HOUR_LIST = Array.from({ length: 24 }, (_, i) =>
+  i.toString().padStart(2, '0'),
+);
+export const MINUTE_LIST = Array.from({ length: 60 }, (_, i) =>
+  i.toString().padStart(2, '0'),
+);


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #66 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 근로일 및 근로일별 근로시간 BottomSheet 구현

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Task1

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

### 공고 수정 및 등록 BottomSheet


https://github.com/user-attachments/assets/49a76298-1132-493f-884d-abf895fed526

### 표준 근로 계약서 BottomSheet


https://github.com/user-attachments/assets/6f87ade5-1e56-4fd4-a08a-cb3090aeef5d

---

일단은 Common에다가 2개의 BottomSheet 컴포넌트로 구현해놨어!

type, 이랑 constant를 분리할까 하다가 오빠가 합치면서 정리하는게 좋을 것 같아서 한 파일 안에 몰아넣었어

그.. 추가하기 눌렀을 때 result 값에다가 api 명세서 형식에 맞게 우선 저장하도록 구현했어!
