### PR TITLE
Feat/IGW-48/72 - 유저 타입별 nav bar 분기

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -49,7 +49,7 @@ function createInstance(type: string) {
     baseURL:
       type === 'kakao'
         ? import.meta.env.VITE_APP_KAKAO_API_BASE_URL
-        : import.meta.env.VITE_APP_API_URL,
+        : import.meta.env.VITE_APP_API_GIGGLE_API_BASE_URL,
   });
   return setInterceptors(instance, type);
 }

--- a/src/components/Common/Navbar.tsx
+++ b/src/components/Common/Navbar.tsx
@@ -31,7 +31,7 @@ const Navbar = () => {
               );
             })}
           {/* 고용자 유저일 경우 nav bar */}
-          {account_type === UserType.USER &&
+          {account_type === UserType.OWNER &&
             employerRoutes.map((route, index) => {
               const IconComponent = route.svg;
               return (

--- a/src/components/Common/Navbar.tsx
+++ b/src/components/Common/Navbar.tsx
@@ -1,52 +1,63 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import HomeIcon from '@/assets/icons/HomeIcon.svg?react';
-import SearchIcon from '@/assets/icons/NavSearchIcon.svg?react';
-import DocumentsIcon from '@/assets/icons/DocumentsIcon.svg?react';
-import ProfileIcon from '@/assets/icons/ProfileIcon.svg?react';
+import { useUserStore } from '@/store/user';
+import { UserType } from '@/constants/user';
+import { employerRoutes, userRoutes, guestRoutes } from '@/constants/routes';
 
 const Navbar = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { account_type } = useUserStore();
 
   const getIconColor = (path: string) => {
     return location.pathname === path ? '#1E1926' : '#DCDCDC';
   };
 
-  const routes = [
-    {
-      path: '/',
-      svg: HomeIcon,
-    },
-    {
-      path: '/search',
-      svg: SearchIcon,
-    },
-    {
-      path: '/application',
-      svg: DocumentsIcon,
-    },
-    {
-      path: '/profile',
-      svg: ProfileIcon,
-    },
-  ];
-
   return (
     <div className="flex justify-center items-center z-50">
       <section className="fixed bottom-0 w-full py-6 px-12 bg-navbarGradient rounded-t-[2rem]">
         <div className="flex justify-between items-center">
-          {routes.map((route, index) => {
-            const IconComponent = route.svg;
-            return (
-              <button key={index} onClick={() => navigate(route.path)}>
-                {route.path == '/profile' ? (
-                  <IconComponent stroke={getIconColor(route.path)} />
-                ) : (
-                  <IconComponent fill={getIconColor(route.path)} />
-                )}
-              </button>
-            );
-          })}
+          {/* 유학생 유저일 경우 nav bar */}
+          {account_type === UserType.USER &&
+            userRoutes.map((route, index) => {
+              const IconComponent = route.svg;
+              return (
+                <button key={index} onClick={() => navigate(route.path)}>
+                  {route.path == '/profile' ? (
+                    <IconComponent stroke={getIconColor(route.path)} />
+                  ) : (
+                    <IconComponent fill={getIconColor(route.path)} />
+                  )}
+                </button>
+              );
+            })}
+          {/* 고용자 유저일 경우 nav bar */}
+          {account_type === UserType.USER &&
+            employerRoutes.map((route, index) => {
+              const IconComponent = route.svg;
+              return (
+                <button key={index} onClick={() => navigate(route.path)}>
+                  {route.path == '/employer/profile' ? (
+                    <IconComponent stroke={getIconColor(route.path)} />
+                  ) : (
+                    <IconComponent fill={getIconColor(route.path)} />
+                  )}
+                </button>
+              );
+            })}
+          {/* 비회원일 경우 nav bar */}
+          {account_type === undefined &&
+            guestRoutes.map((route, index) => {
+              const IconComponent = route.svg;
+              return (
+                <button key={index} onClick={() => navigate(route.path)}>
+                  {route.path == '/profile' ? (
+                    <IconComponent stroke={getIconColor(route.path)} />
+                  ) : (
+                    <IconComponent fill={getIconColor(route.path)} />
+                  )}
+                </button>
+              );
+            })}
         </div>
       </section>
     </div>

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -13,6 +13,7 @@ import RadioButton from '@/components/Information/RadioButton';
 import { InputType } from '@/types/common/input';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
+import { formatDateToDash } from '../../utils/editResume';
 
 const InformationStep = ({
   userInfo,
@@ -205,6 +206,8 @@ const InformationStep = ({
                   nationality: newUserInfo.nationality
                     ?.toUpperCase()
                     .replace(/\s/g, '_'),
+                  birth: formatDateToDash(newUserInfo.birth as string),
+                  visa: newUserInfo.visa?.replace('-', '_'),
                 },
               })
             }

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -207,7 +207,7 @@ const InformationStep = ({
                     ?.toUpperCase()
                     .replace(/\s/g, '_'),
                   birth: formatDateToDash(newUserInfo.birth as string),
-                  visa: newUserInfo.visa?.replace('-', '_'),
+                  visa: newUserInfo.visa?.replace(/-/g, '_'),
                 },
               })
             }

--- a/src/components/Signin/SigninInputSection.tsx
+++ b/src/components/Signin/SigninInputSection.tsx
@@ -31,7 +31,12 @@ const SigninInputSection = () => {
 
   // ====== Sign in API =======
   const handleSubmit = async () => {
-    signIn({ serial_id: idValue, password: passwordValue });
+    // signIn({ serial_id: idValue, password: passwordValue });
+    const formData = new FormData();
+    formData.append('serial_id', idValue);
+    formData.append('password', passwordValue);
+
+    signIn(formData);
   };
 
   // 모든 필드의 유효성 검사 후, Sign In 버튼 활성화

--- a/src/components/Splash/Splash.tsx
+++ b/src/components/Splash/Splash.tsx
@@ -65,6 +65,7 @@ const Splash = () => {
         } else {
           // UserTypeResponse가 정의되지 않은 경우
           setGuest();
+          return;
         }
       }
     } catch (error) {

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,61 @@
+import HomeIcon from '@/assets/icons/HomeIcon.svg?react';
+import SearchIcon from '@/assets/icons/NavSearchIcon.svg?react';
+import DocumentsIcon from '@/assets/icons/DocumentsIcon.svg?react';
+import ProfileIcon from '@/assets/icons/ProfileIcon.svg?react';
+
+export const userRoutes = [
+  {
+    path: '/',
+    svg: HomeIcon,
+  },
+  {
+    path: '/search',
+    svg: SearchIcon,
+  },
+  {
+    path: '/application',
+    svg: DocumentsIcon,
+  },
+  {
+    path: '/profile',
+    svg: ProfileIcon,
+  },
+];
+
+export const employerRoutes = [
+  {
+    path: '/',
+    svg: HomeIcon,
+  },
+  {
+    path: '/search',
+    svg: SearchIcon,
+  },
+  {
+    path: '/employer/post',
+    svg: DocumentsIcon,
+  },
+  {
+    path: '/employer/profile',
+    svg: ProfileIcon,
+  },
+];
+
+export const guestRoutes = [
+  {
+    path: '/',
+    svg: HomeIcon,
+  },
+  {
+    path: '/search',
+    svg: SearchIcon,
+  },
+  {
+    path: '/signin',
+    svg: DocumentsIcon,
+  },
+  {
+    path: '/signin',
+    svg: ProfileIcon,
+  },
+];

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -29,6 +29,7 @@ import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useEmailTryCountStore } from '@/store/signup';
 import { useUserStore } from '@/store/user';
+import { RESTYPE } from '@/types/api/common';
 
 /**
  * 로그인 프로세스를 처리하는 커스텀 훅
@@ -59,9 +60,9 @@ export const useSignIn = () => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: signIn,
-    onSuccess: (data) => {
-      setAccessToken(data.access_token);
-      setRefreshToken(data.refresh_token);
+    onSuccess: (data: RESTYPE<SignInResponse>) => {
+      setAccessToken(data.data.access_token);
+      setRefreshToken(data.data.refresh_token);
       navigate('/splash');
     },
     onError: () => {
@@ -97,9 +98,9 @@ export const useReIssueToken = () => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: reIssueToken,
-    onSuccess: (data: SignInResponse) => {
-      setAccessToken(data.access_token);
-      setRefreshToken(data.refresh_token);
+    onSuccess: (data: RESTYPE<SignInResponse>) => {
+      setAccessToken(data.data.access_token);
+      setRefreshToken(data.data.refresh_token);
       navigate('/splash'); // 재발급 후 유형 확인
     },
   });
@@ -144,10 +145,11 @@ export const useSignUp = () => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: signUp,
-    onSuccess: (data: SignInResponse) => {
+    onSuccess: (data: RESTYPE<SignInResponse>) => {
+      console.log(data);
       deleteTemporaryToken();
-      setAccessToken(data.access_token);
-      setRefreshToken(data.refresh_token);
+      setAccessToken(data.data.access_token);
+      setRefreshToken(data.data.refresh_token);
     },
     onError: () => {
       navigate('/');
@@ -160,8 +162,8 @@ export const usePatchAuthentication = () => {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: patchAuthentication,
-    onSuccess: (data: AuthenticationResponse) => {
-      setTemporaryToken(data.temporary_token);
+    onSuccess: (data: RESTYPE<AuthenticationResponse>) => {
+      setTemporaryToken(data.data.temporary_token);
       navigate('/information');
     },
     onError: (error) => {
@@ -176,9 +178,9 @@ export const useReIssueAuthentication = () => {
   const { updateTryCnt } = useEmailTryCountStore();
   return useMutation({
     mutationFn: reIssueAuthentication,
-    onSuccess: (data: TempSignUpResponse) => {
+    onSuccess: (data: RESTYPE<TempSignUpResponse>) => {
       // 이메일 재발송 횟수 업데이트
-      updateTryCnt(data.try_cnt);
+      updateTryCnt(data.data.try_cnt);
     },
     onError: () => {
       navigate('/signup');

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -146,7 +146,6 @@ export const useSignUp = () => {
   return useMutation({
     mutationFn: signUp,
     onSuccess: (data: RESTYPE<SignInResponse>) => {
-      console.log(data);
       deleteTemporaryToken();
       setAccessToken(data.data.access_token);
       setRefreshToken(data.data.refresh_token);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -39,20 +39,30 @@ import EmployerApplicantResumePage from '@/pages/Employer/ApplicantResume/Employ
 import EmployerApplicantResumeAcceptPage from '@/pages/Employer/ApplicantResumeAccept/EmployerApplicantResumeAcceptPage';
 import AlarmPage from '@/pages/Alarm/AlarmPage';
 import ChatBotPage from '@/pages/ChatBot/ChatBotPage';
+import { useUserStore } from '@/store/user';
+import { UserType } from '@/constants/user';
+import Splash from '@/components/Splash/Splash';
+import EmployerSignupPage from './pages/Employer/signup/EmployerSignupPage';
 
 const Layout = () => {
   const location = useLocation();
+  const { account_type } = useUserStore();
 
   // Nav bar 컴포넌트가 랜딩되는 페이지
-  const showNavbarPaths = ['/', '/profile', '/search', '/application'];
+  const showNavbarPaths = () => {
+    if (account_type === UserType.OWNER) {
+      return ['/', '/search', '/employer/post', '/employer/profile'];
+    } else return ['/', '/search', '/application', '/profile'];
+  };
 
-  const shouldShowNavbar = showNavbarPaths.includes(location.pathname);
+  const shouldShowNavbar = showNavbarPaths().includes(location.pathname);
 
   return (
     <>
       <ScrollToTop />
       <Outlet />
       {shouldShowNavbar && <Navbar />}
+      {console.log(account_type)}
     </>
   );
 };
@@ -63,6 +73,7 @@ const Router = () => {
       <Routes>
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/splash" element={<Splash />} />
           <Route path="/chatbot" element={<ChatBotPage />} />
           <Route path="/alarm" element={<AlarmPage />} />
           <Route path="/signin" element={<SigninPage />} />
@@ -102,6 +113,7 @@ const Router = () => {
 
           <Route path="/post/:id" element={<PostDetailPage />} />
           <Route path="/post/apply/:id" element={<PostApplyPage />} />
+          <Route path="/employer/signup" element={<EmployerSignupPage />} />
           <Route
             path="/employer/signup/information"
             element={<EmployerSignupInfoPage />}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -62,7 +62,6 @@ const Layout = () => {
       <ScrollToTop />
       <Outlet />
       {shouldShowNavbar && <Navbar />}
-      {console.log(account_type)}
     </>
   );
 };

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,10 +1,7 @@
 import { UserType } from '@/constants/user';
 import { Address, Language, UserInfo } from '@/types/api/users';
 
-export type SignInRequest = {
-  serial_id: string;
-  password: string;
-};
+export type SignInRequest = FormData;
 
 export type SignInResponse = {
   access_token: string;


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #72

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 로그인 이후 유저 타입 판별
1. 로그인 이후 스플래시 화면에서 3초간 머물고 유저 타입을 확인합니다.
2. 유저 타입은 useUserStore에 account_type, name으로 저장됩니다.
2-1. 유저 타입이 유학생일 경우, 유학생 페이지를 nav bar에 연결합니다.
2-2. 고용주 타입일 경우 해당 페이지를 nav bar에 연결합니다.
2-3. 비로그인 유저일 경우 '홈', '검색' 페이지는 nav bar를 통해 접속 가능하지만 '서류확인', '마이페이지' 접속이 불가하며 로그인 페이지로 이동됩니다.

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] N/A

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
