### PR TITLE
Fix/109 - 기타 언어 레벨 UI, ID 중복검사 수정

### DIFF
--- a/src/components/Language/EtcLevelSection.tsx
+++ b/src/components/Language/EtcLevelSection.tsx
@@ -23,13 +23,11 @@ const EtcLevelSection = ({ level, setLevel }: EtcLevelSectionProps) => {
       </p>
       {/* 레벨 선택 바텀시트 */}
       {bottomSheetOpen && (
-        <div className="w-screen h-screen">
-          <LevelBottomSheet
-            level={level}
-            setLevel={setLevel}
-            setBottomSheetOpen={setBottomSheetOpen}
-          />
-        </div>
+        <LevelBottomSheet
+          level={level}
+          setLevel={setLevel}
+          setBottomSheetOpen={setBottomSheetOpen}
+        />
       )}
     </>
   );

--- a/src/components/Signin/SigninInputSection.tsx
+++ b/src/components/Signin/SigninInputSection.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/Common/Button';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { validateId, validatePassword } from '@/utils/signin';
 import { useSignIn } from '@/hooks/api/useAuth';
+import { useUserInfoforSigninStore } from '@/store/signup';
 
 const SigninInputSection = () => {
   const navigate = useNavigate();
@@ -17,6 +18,7 @@ const SigninInputSection = () => {
   const [isValid, setIsValid] = useState(false);
 
   const { mutate: signIn } = useSignIn();
+  const { updateId, updatePassword } = useUserInfoforSigninStore();
 
   // ===== handler =====
   const handleIdChange = (value: string) => {
@@ -36,6 +38,11 @@ const SigninInputSection = () => {
     formData.append('serial_id', idValue);
     formData.append('password', passwordValue);
 
+    // 전역 상태 업데이트
+    updateId(idValue);
+    updatePassword(passwordValue);
+
+    // api 훅 호출
     signIn(formData);
   };
 

--- a/src/components/Signup/SignupInput.tsx
+++ b/src/components/Signup/SignupInput.tsx
@@ -58,8 +58,6 @@ const SignupInput = ({
     // ID 중복 검사
     const validateIdAsync = async () => {
       if (validationResponse && validationResponse.data.is_valid === false) {
-        console.log(signInputTranclation.idAvailability[isEmployer(pathname)]);
-
         setIdError(signInputTranclation.idAvailability[isEmployer(pathname)]);
         setIdValid(false);
       }

--- a/src/components/Signup/SignupInput.tsx
+++ b/src/components/Signup/SignupInput.tsx
@@ -31,44 +31,62 @@ const SignupInput = ({
 
   // // ===== state =====
   const [confirmPasswordValue, setConfirmPasswordValue] = useState<string>('');
-  const [idError, setIdError] = useState<string | null>(null);
-  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [idError, setIdError] = useState<string | null>();
+  const [passwordError, setPasswordError] = useState<string | null>();
   const [confirmPasswordError, setConfirmPasswordError] = useState<
     string | null
   >(null);
   const [isValid, setIsValid] = useState(false);
+  const [idValid, setIdValid] = useState(false);
 
   const { data: validationResponse } = useGetIdValidation(id);
 
-  // ===== handler =====
-  const handleIdChange = async (value: string) => {
-    onIdChange(value);
+  // ID 검사
+  useEffect(() => {
+    if (!id) {
+      setIdError(null);
+      setIdValid(false);
+      return;
+    }
+    onIdChange(id);
 
     // ID 유효성 검사
-    if (validateId(value, setIdError, pathname)) {
-      // ID 중복 검사 API 호출 결과 처리
-      if (validationResponse && validationResponse.data.is_valid) {
-        setIdError(null); // ID 중복 오류 메시지 초기화
-      } else {
-        setIdError(signInputTranclation.invalidId[isEmployer(pathname)]); // ID 중복 오류 메시지
-      }
+    if (validateId(id, setIdError, pathname)) {
+      setIdValid(true);
     }
-  };
 
-  const handlePasswordChange = (value: string) => {
-    onPasswordChange(value);
-    validatePassword(value, setPasswordError, pathname); // 비밀번호 입력 시 유효성 검사
-  };
+    // ID 중복 검사
+    const validateIdAsync = async () => {
+      if (validationResponse && validationResponse.data.is_valid === false) {
+        console.log(signInputTranclation.idAvailability[isEmployer(pathname)]);
 
-  const handleConfirmPasswordChange = (value: string) => {
-    setConfirmPasswordValue(value);
-    validatedConfirmPassword(
-      password,
-      value,
-      setConfirmPasswordError,
-      pathname,
-    );
-  };
+        setIdError(signInputTranclation.idAvailability[isEmployer(pathname)]);
+        setIdValid(false);
+      }
+    };
+
+    validateIdAsync();
+  }, [id, onIdChange, validationResponse, idError, idValid]);
+
+  // password 유효성 검사
+  useEffect(() => {
+    if (password) {
+      onPasswordChange(password);
+      validatePassword(password, setPasswordError, pathname);
+    }
+  }, [password, pathname, onPasswordChange]);
+
+  // password 일치 유효성 검사
+  useEffect(() => {
+    if (confirmPasswordValue) {
+      validatedConfirmPassword(
+        password,
+        confirmPasswordValue,
+        setConfirmPasswordError,
+        pathname,
+      );
+    }
+  }, [password, confirmPasswordValue, pathname]);
 
   // 모든 필드의 유효성 검사 후, Continue 버튼 활성화
   useEffect(() => {
@@ -80,6 +98,10 @@ const SignupInput = ({
       setIsValid(true);
     }
   }, [id, password, confirmPasswordValue]);
+
+  const handleConfirmPasswordChange = (value: string) => {
+    setConfirmPasswordValue(value);
+  };
 
   return (
     <>
@@ -96,11 +118,13 @@ const SignupInput = ({
               inputType="TEXT"
               placeholder={signInputTranclation.enterId[isEmployer(pathname)]}
               value={id}
-              onChange={handleIdChange}
+              onChange={onIdChange}
               canDelete={false}
-              isInvalid={!!idError}
+              isInvalid={!idValid}
             />
-            {idError && <p className="text-[#FF6F61] text-xs p-2">{idError}</p>}
+            {!idValid && (
+              <p className="text-[#FF6F61] text-xs p-2">{idError}</p>
+            )}
           </div>
           <div>
             <p className="py-2 px-1 body-2 text-[#656565]">
@@ -112,9 +136,9 @@ const SignupInput = ({
                 signInputTranclation.enterPassword[isEmployer(pathname)]
               }
               value={password}
-              onChange={handlePasswordChange}
+              onChange={onPasswordChange}
               canDelete={false}
-              isInvalid={!!passwordError}
+              isInvalid={passwordError ? true : false}
             />
             {passwordError && (
               <p className="text-[#FF6F61] text-xs p-2">{passwordError}</p>
@@ -132,7 +156,7 @@ const SignupInput = ({
               value={confirmPasswordValue}
               onChange={handleConfirmPasswordChange}
               canDelete={false}
-              isInvalid={!!confirmPasswordError}
+              isInvalid={confirmPasswordError ? true : false}
             />
             {confirmPasswordError && (
               <p className="text-[#FF6F61] text-xs p-2">

--- a/src/constants/translation.ts
+++ b/src/constants/translation.ts
@@ -19,6 +19,10 @@ export const signInputTranclation = {
     ko: '아이디를 입력해주세요',
     en: 'Invalid id format',
   },
+  idAvailability: {
+    ko: '아이디가 이미 존재합니다',
+    en: 'This id already exists',
+  },
   password: {
     ko: '비밀번호',
     en: 'Password',

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -28,7 +28,10 @@ import {
 } from '@/utils/auth';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useEmailTryCountStore } from '@/store/signup';
+import {
+  useEmailTryCountStore,
+  useUserInfoforSigninStore,
+} from '@/store/signup';
 import { useUserStore } from '@/store/user';
 import { RESTYPE } from '@/types/api/common';
 
@@ -162,6 +165,9 @@ export const useTempSignUp = () => {
 // 2.5  기본 유저 회원가입 훅
 export const useSignUp = () => {
   const navigate = useNavigate();
+  const { id, password, updateId, updatePassword } =
+    useUserInfoforSigninStore();
+
   return useMutation({
     mutationFn: signUp,
     onSuccess: (data: RESTYPE<SignInResponse>) => {
@@ -169,6 +175,26 @@ export const useSignUp = () => {
         deleteTemporaryToken();
         setAccessToken(data.data.access_token);
         setRefreshToken(data.data.refresh_token);
+
+        // 회원가입 후 자동 로그인
+        const signinData = new FormData();
+        signinData.append('serial_id', id);
+        signinData.append('password', password);
+
+        // 로그인 hook 호출
+        const { mutate: signin } = useSignIn();
+        signin(signinData, {
+          onSuccess: () => {
+            navigate('/splash');
+          },
+          onError: () => {
+            navigate('/signin');
+          },
+        });
+
+        // id, password 저장소 삭제
+        updateId('');
+        updatePassword('');
       }
     },
     onError: () => {

--- a/src/store/signup.ts
+++ b/src/store/signup.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 
+// 회원가입시, 이메일 인증 횟수 제한 확인을 위한 전역상태 관리
 type EmailTryCountStore = {
   try_cnt: number;
   updateTryCnt: (cnt: number) => void;
@@ -9,3 +10,20 @@ export const useEmailTryCountStore = create<EmailTryCountStore>()((set) => ({
   try_cnt: 0,
   updateTryCnt: (try_cnt) => set(() => ({ try_cnt: try_cnt })),
 }));
+
+// 회원가입 후 자동 로그인을 위한 전역상태 관리
+type userInfoforSigninStore = {
+  id: string;
+  password: string;
+  updateId: (id: string) => void;
+  updatePassword: (password: string) => void;
+};
+
+export const useUserInfoforSigninStore = create<userInfoforSigninStore>()(
+  (set) => ({
+    id: '',
+    password: '',
+    updateId: (id) => set(() => ({ id: id })),
+    updatePassword: (password) => set(() => ({ password: password })),
+  }),
+);


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- #109

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 기타 언어 레벨 선택할 때의 바텀시트가 깨져 보이는 현상 fix 했습니다.
- ID, email 중복일 경우, 에러 코드 동기화 했습니다.

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] N/A

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
