### PR TITLE
[fix] days a week 문구는 제외하기!

### DIFF
--- a/src/components/PostDetail/PostDetailTitle.tsx
+++ b/src/components/PostDetail/PostDetailTitle.tsx
@@ -66,7 +66,7 @@ const PostDetailTitle = ({ postDetailData }: PostDetailTitleProps) => {
         <div className="flex gap-[0.5rem] px-[0.5rem]">
           <ClockIcon className="min-w-[0.5rem]" />
           <p className="text-[#464646] caption-1">
-            {postDetailData.summaries.work_days_per_week} days a week
+            {postDetailData.summaries.work_days_per_week}
           </p>
         </div>
         <div className="flex justify-end gap-[0.5rem] px-[0.5rem]">


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 공고 상세 페이지에서 days a week라는 단위를 붙인 것을 제외하기!

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Task1

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
