### PR TITLE
🐛 fix: igw-55/127 - 유학생/고용주 서류작성 버그 해결

### DIFF
--- a/src/components/Common/Input.tsx
+++ b/src/components/Common/Input.tsx
@@ -85,7 +85,7 @@ const Input = ({
 
   return (
     <div
-      className={`w-full flex gap-2 items-center justify-between text-left body-2 border rounded-xl ${inputStyler(currentStatus)} bg-white py-[10px] pl-4 pr-[14px]`}
+      className={`w-full flex gap-2 whitespace-nowrap items-center justify-between text-left body-2 border rounded-xl ${inputStyler(currentStatus)} bg-white py-[10px] pl-4 pr-[14px]`}
     >
       {/* 접두사가 존재할 경우 표시합니다. */}
       {isPrefix && <div className="w-8 body-2 text-[#464646]">{prefix}</div>}

--- a/src/components/Document/DocumentCard.tsx
+++ b/src/components/Document/DocumentCard.tsx
@@ -8,8 +8,14 @@ import DownloadIcon from '@/assets/icons/DownloadIcon.svg?react';
 import CheckIconGreen from '@/assets/icons/CheckIconGreen.svg?react';
 import WriteIcon from '@/assets/icons/WriteIcon.svg?react';
 import { useNavigate } from 'react-router-dom';
-import { usePatchDocumentsStatusConfirmation, usePatchStatusSubmission } from '@/hooks/api/useDocument';
-import { useCurrentDocumentIdStore, useCurrentPostIdEmployeeStore } from '@/store/url';
+import {
+  usePatchDocumentsStatusConfirmation,
+  usePatchStatusSubmission,
+} from '@/hooks/api/useDocument';
+import {
+  useCurrentDocumentIdStore,
+  useCurrentPostIdEmployeeStore,
+} from '@/store/url';
 
 const enum DocumentStatus {
   TEMPORARY_SAVE = 'TEMPORARY_SAVE',
@@ -42,8 +48,8 @@ const TemporarySaveCard = ({
       <div className="self-stretch rounded-t-[1.125rem] bg-[#fef387] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
         <div className="flex items-center justify-start relative ">
           Check my Work Permit Form
+          <div className="w-1.5 absolute !m-0 top-[-0.3rem] right-[-0.5rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
         </div>
-        <div className="w-1.5 absolute !m-0 top-[0.4rem] left-[8rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
         <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
           <div
             className="absolute w-full h-full top-0 righ-0 bottom-0 left-0"
@@ -114,13 +120,12 @@ const BeforeConfirmationCard = ({
       <div className="self-stretch rounded-t-[1.125rem] bg-[#fef387] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
         <div className="flex items-center justify-start relative ">
           Check my Work Permit Form
+          <div className="w-1.5 absolute !m-0 top-[-0.3rem] right-[-0.5rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
         </div>
-        <div className="w-1.5 absolute !m-0 top-[0.4rem] left-[8rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
-        <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
-          <div
-            className="absolute w-full h-full top-0 righ-0 bottom-0 left-0"
-            onClick={onPreview}
-          />
+        <div
+          className="pl-1 w-[1.25rem] relative h-[1.25rem] z-[2]"
+          onClick={onPreview}
+        >
           <ArrowrightIcon />
         </div>
       </div>
@@ -271,13 +276,12 @@ const ConfirmationCard = ({
       <div className="self-stretch rounded-t-[1.125rem] bg-[#fef387] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
         <div className="flex items-center justify-start relative ">
           Check my Work Permit Form
+          <div className="w-1.5 absolute !m-0 top-[-0.3rem] right-[-0.5rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
         </div>
-        <div className="w-1.5 absolute !m-0 top-[0.4rem] left-[8rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
-        <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
-          <div
-            className="absolute w-full h-full top-0 righ-0 bottom-0 left-0"
-            onClick={onPreview}
-          />
+        <div
+          className="pl-1 w-[1.25rem] relative h-[1.25rem] z-[2]"
+          onClick={onPreview}
+        >
           <ArrowrightIcon />
         </div>
       </div>
@@ -350,8 +354,8 @@ const DocumentCardDispenser = ({
   const { mutate: confirmDocument } = usePatchDocumentsStatusConfirmation();
   const navigate = useNavigate();
   const { updateCurrentDocumentId } = useCurrentDocumentIdStore();
-  const { currentPostId }= useCurrentPostIdEmployeeStore();
-  console.log(`current: ${currentPostId}`) // 지원자 조회 - 지원자 상세 - 서류 상세 간 뒤로가기 문제 관련
+  const { currentPostId } = useCurrentPostIdEmployeeStore();
+  console.log(`current: ${currentPostId}`); // 지원자 조회 - 지원자 상세 - 서류 상세 간 뒤로가기 문제 관련
   const handleDownload = (url: string) => {
     window.open(url, '_blank');
   };

--- a/src/components/Document/write/EmployerInfoSection.tsx
+++ b/src/components/Document/write/EmployerInfoSection.tsx
@@ -60,7 +60,9 @@ const EmployerInfoSection = ({
                 ].includes(key) && (
                   <div className="w-full self-stretch drop-shadow-[0_1px_2px_rgba(107,110,116,0.04)] rounded-xl flex items-center justify-start py-2.5 pr-3.5 pl-4">
                     <div className="w-full flex-1 relative">
-                      {propertyToString(String(value))}
+                      {propertyToString(String(value)) === 'Null'
+                        ? 'none'
+                        : propertyToString(String(value))}
                     </div>
                   </div>
                 )}

--- a/src/components/Employer/ApplicantDocumentsDetail/DocumentCardDispenserEmployer.tsx
+++ b/src/components/Employer/ApplicantDocumentsDetail/DocumentCardDispenserEmployer.tsx
@@ -20,11 +20,7 @@ type DocumentCardProps = {
   onNext?: () => void;
 };
 
-const NullCard = ({
-  title,
-}: {
-  title: string;
-}) => {
+const NullCard = ({ title }: { title: string }) => {
   return (
     <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
       <div className="self-stretch rounded-t-[1.125rem] bg-[#1e1926] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
@@ -67,20 +63,24 @@ const TemporarySaveCard = ({
   title,
   onNext,
   onEdit,
+  onPreview,
 }: {
   title: string;
   onNext: () => void;
   onEdit: () => void;
+  onPreview: () => void;
 }) => {
   return (
     <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
       <div className="self-stretch rounded-t-[1.125rem] bg-[#fef387] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
         <div className="flex items-center justify-start relative ">
-          클릭해서 서류 내용을 확인해보세요
+          클릭해서 서류 내용을 확인해보세요.
+          <div className="w-1.5 absolute !m-0 top-[-0.3rem] right-[-0.5rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
         </div>
-        <div className="w-1.5 absolute !m-0 top-[0.4rem] left-[8rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
-        <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
-          <div className="absolute w-full h-full top-0 righ-0 bottom-0 left-0" />
+        <div
+          className="pl-1 w-[1.25rem] relative h-[1.25rem] z-[2]"
+          onClick={onPreview}
+        >
           <ArrowrightIcon />
         </div>
       </div>
@@ -129,7 +129,8 @@ const TemporarySaveCard = ({
   );
 };
 
-{/* 
+{
+  /* 
   const BeforeConfirmationCard = ({ title }: { title: string }) => {
   return (
     <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
@@ -168,7 +169,8 @@ const TemporarySaveCard = ({
     </div>
   );
 };
-  */}
+  */
+}
 
 const SubmittedCard = ({ title }: { title: string }) => {
   return (
@@ -213,22 +215,26 @@ const RewritingCard = ({
   title,
   onNext,
   onEdit,
+  onPreview,
   reason,
 }: {
   title: string;
   onNext: () => void;
   onEdit: () => void;
+  onPreview: () => void;
   reason: string;
 }) => {
   return (
     <div className="w-full relative rounded-[1.125rem] bg-white border border-[#dcdcdc] flex flex-col items-center justify-center gap-2 caption-2 text-left text-[#1e1926]">
       <div className="self-stretch rounded-t-[1.125rem] bg-[#fef387] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
         <div className="flex items-center justify-start relative ">
-          Check my Work Permit Form
+          클릭해서 서류 내용을 확인해보세요.
+          <div className="w-1.5 absolute !m-0 top-[-0.3rem] right-[-0.5rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
         </div>
-        <div className="w-1.5 absolute !m-0 top-[0.4rem] left-[8rem] rounded-full bg-[#ff6f61] h-1.5 z-[1]" />
-        <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
-          <div className="absolute w-full h-full top-0 righ-0 bottom-0 left-0" />
+        <div
+          className="pl-1 w-[1.25rem] relative h-[1.25rem] z-[2]"
+          onClick={onPreview}
+        >
           <ArrowrightIcon />
         </div>
       </div>
@@ -282,6 +288,7 @@ const ConfirmationCard = ({
 }: {
   title: string;
   document: EmployDocumentInfo;
+  
   onDownload: (url: string) => void;
 }) => {
   return (
@@ -289,10 +296,6 @@ const ConfirmationCard = ({
       <div className="self-stretch rounded-t-[1.125rem] bg-[#1e1926] h-7 flex items-center justify-between px-4 pl-6 py-2 relative">
         <div className="flex items-center justify-start relative text-[#fef387]">
           서류 작성이 완료되었습니다.
-        </div>
-        <div className="w-[0.75rem] relative h-[0.75rem] z-[2]">
-          <div className="absolute w-full h-full top-0 righ-0 bottom-0 left-0" />
-          <ArrowrightIcon />
         </div>
       </div>
       <div className="self-stretch flex flex-col items-start px-4 gap-4 body-1">
@@ -360,7 +363,7 @@ const DocumentCardDispenserEmployer = ({
   const handleDownload = (url: string) => {
     window.open(url, '_blank');
   };
-  const {updateCurrentDocumentId} = useCurrentDocumentIdStore();
+  const { updateCurrentDocumentId } = useCurrentDocumentIdStore();
   const { mutate: submitDocument } = usePatchStatusSubmissionEmployer();
   if (!document.status) return <NullCard title={title} />;
   switch (document.status) {
@@ -375,6 +378,14 @@ const DocumentCardDispenserEmployer = ({
               state: {
                 type: type,
                 isEdit: true,
+              },
+            });
+          }}
+          onPreview={() => {
+            updateCurrentDocumentId(document.id);
+            navigate(`/document-preview/${document.id}`, {
+              state: {
+                type: type,
               },
             });
           }}
@@ -395,6 +406,14 @@ const DocumentCardDispenserEmployer = ({
                 state: {
                   type: type,
                   isEdit: true,
+                },
+              });
+            }}
+            onPreview={() => {
+              updateCurrentDocumentId(document.id);
+              navigate(`/document-preview/${document.id}`, {
+                state: {
+                  type: type,
                 },
               });
             }}

--- a/src/components/Employer/WriteDocument/EmployeeInfoSectionKOR.tsx
+++ b/src/components/Employer/WriteDocument/EmployeeInfoSectionKOR.tsx
@@ -11,7 +11,7 @@ import {
   LaborContractEmployeeInfoProperty,
 } from '@/types/api/document';
 import { Address } from '@/types/api/users';
-import { getDetailAddress, getImageType } from '@/utils/document';
+import { getDetailAddress } from '@/utils/document';
 import { renderMap } from '@/utils/map';
 
 const EmployeeInfoSectionKOR = ({
@@ -70,8 +70,8 @@ const EmployeeInfoSectionKOR = ({
                   <div className="border border-gray-200 rounded-xl">
                     {value !== '' && (
                       <img
-                        src={`data:image/${getImageType(value)};base64,${value}`}
-                        className="w-full h-full object-cover"
+                        src={`data:image/svg+xml;base64,${value}`}
+                        className="w-full h-full object-cover bg-white rounded-xl"
                         alt="signature preview"
                       />
                     )}

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -4,7 +4,7 @@ import InputLayout from '@/components/WorkExperience/InputLayout';
 import {
   DAYS,
   initialLaborContractEmployerInfo,
-  INSURANCES,
+  InsuranceInfo,
 } from '@/constants/documents';
 import { useSearchAddress } from '@/hooks/api/useKaKaoMap';
 import {
@@ -112,10 +112,6 @@ const EmployerLaborContractForm = ({
 
   /* 정보 입력 시마다 유효성을 검사해 모든 값이 유효하면 버튼이 활성화 */
   useEffect(() => {
-    {
-      /* work_day_time_list 데이터가 안 들어가서 계속 유효성 실패 중 */
-    }
-    console.log(newDocumentData.work_day_time_list);
     setIsInvalid(
       !validateLaborContractEmployerInformation({
         ...newDocumentData,
@@ -608,40 +604,53 @@ const EmployerLaborContractForm = ({
           isEssential
         >
           <div className="w-full flex">
-            {Object.keys(INSURANCES).map((value, index) => (
-              <div
-                className="w-full relative flex items-center justify-start py-2 gap-2 text-left body-3 text-[#656565]"
-                key={`${value}_${index}`}
-              >
-                <div className="w-6 h-6 relative">
-                  <div
-                    className={`w-full h-full border border-[#f4f4f9] flex items-center justify-center ${newDocumentData.insurance.includes(value as Insurance) ? 'bg-[#1E1926]' : 'bg-white'}`}
-                    onClick={() => {
-                      const newInsurance = newDocumentData.insurance.includes(
-                        value as Insurance,
-                      )
-                        ? newDocumentData.insurance.filter(
-                            (insurance) => insurance !== value,
-                          )
-                        : [...newDocumentData.insurance, value];
+            {Object.entries(InsuranceInfo).map(
+              ([insuranceType, info], index) => (
+                <div
+                  className="w-full relative flex items-center justify-start py-2 gap-2 text-left body-3 text-[#656565]"
+                  key={`${insuranceType}_${index}`}
+                >
+                  <div className="w-6 h-6 relative">
+                    <div
+                      className={`w-full h-full border border-[#f4f4f9] flex items-center justify-center ${
+                        newDocumentData.insurance.includes(
+                          info.key as Insurance,
+                        )
+                          ? 'bg-[#1E1926]'
+                          : 'bg-white'
+                      }`}
+                      onClick={() => {
+                        const newInsurance = newDocumentData.insurance.includes(
+                          info.key as Insurance,
+                        )
+                          ? newDocumentData.insurance.filter(
+                              (insurance) => insurance !== info.key,
+                            )
+                          : [
+                              ...newDocumentData.insurance,
+                              info.key as Insurance,
+                            ];
 
-                      setNewDocumentData({
-                        ...newDocumentData,
-                        insurance: newInsurance as Insurance[],
-                      });
-                    }}
-                  >
-                    <CheckIcon />
+                        setNewDocumentData({
+                          ...newDocumentData,
+                          insurance: newInsurance,
+                        });
+                      }}
+                    >
+                      <CheckIcon />
+                    </div>
+                  </div>
+                  <div className="flex items-start justify-start">
+                    {info.name}
                   </div>
                 </div>
-                <div className="flex items-start justify-start">{value}</div>
-              </div>
-            ))}
+              ),
+            )}
           </div>
         </InputLayout>
         {/* 서명 입력 */}
         <InputLayout title="서명" isEssential>
-          <SignaturePad
+        <SignaturePad
             onSave={(signature: string) =>
               setNewDocumentData({
                 ...newDocumentData,
@@ -655,6 +664,7 @@ const EmployerLaborContractForm = ({
               })
             }
             isKorean
+            previewImg={newDocumentData.signature_base64}
           />
         </InputLayout>
       </div>

--- a/src/components/Home/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader.tsx
@@ -15,8 +15,6 @@ const HomeHeader = () => {
     return isRead;
   };
 
-  if (!data?.success) return <></>;
-
   return (
     <section className="w-full pt-[3.125rem] pb-[1rem] px-[1.5rem] bg-[#FEF387]">
       <p className="pb-[0.375rem] body-2 text-[#37383C9C]">
@@ -40,7 +38,7 @@ const HomeHeader = () => {
           >
             <AlarmIcon />
             {/* 알람이 있을 때만 표시하기 */}
-            {isReadAlarms(data?.data?.notification_list) ? (
+            {data?.success && isReadAlarms(data?.data?.notification_list) ? (
               <div className="absolute top-[0.3rem] right-[0.4rem] w-[0.438rem] h-[0.438rem] rounded-full bg-[#FF6F61]"></div>
             ) : (
               <></>

--- a/src/constants/documents.ts
+++ b/src/constants/documents.ts
@@ -208,6 +208,14 @@ export const LaborContractEmployerInfoNameMap = {
     name: 'Company name',
     key: 'company_name',
   },
+  [LaborContractEmployerInfoProperty.COMPANY_REGISTRATION_NUMBER]: {
+    name: 'Company Registration Number',
+    key: 'company_registration_number',
+  },
+  [LaborContractEmployerInfoProperty.PHONE_NUMBER]: {
+    name: 'Company Phone Number',
+    key: 'phone_number',
+  },
   [LaborContractEmployerInfoProperty.NAME]: {
     name: 'Representative name',
     key: 'name',

--- a/src/constants/documents.ts
+++ b/src/constants/documents.ts
@@ -674,9 +674,21 @@ export const DAYS = {
   ['일요일']: 'SUNDAY',
 } as const;
 
-export const INSURANCES = {
-  ['고용보험']: 'EMPLOYMENT_INSURANCE',
-  ['산재보험']: 'WORKERS_COMPENSATION_INSURANCE',
-  ['국민연금']: 'NATIONAL_PENSION',
-  ['건강보험']: 'HEALTH_INSURANCE',
-};
+export const InsuranceInfo = {
+  [Insurance.EMPLOYMENT_INSURANCE]: {
+    name: '고용보험',
+    key: 'EMPLOYMENT_INSURANCE',
+  },
+  [Insurance.WORKERS_COMPENSATION_INSURANCE]: {
+    name: '산재보험',
+    key: 'WORKERS_COMPENSATION_INSURANCE',
+  },
+  [Insurance.NATIONAL_PENSION]: {
+    name: '국민연금',
+    key: 'NATIONAL_PENSION',
+  },
+  [Insurance.HEALTH_INSURANCE]: {
+    name: '건강보험',
+    key: 'HEALTH_INSURANCE',
+  },
+} as const;

--- a/src/hooks/api/useDocument.ts
+++ b/src/hooks/api/useDocument.ts
@@ -137,7 +137,7 @@ export const usePutLaborContractEmployer = (id: number) => {
   return useMutation({
     mutationFn: putLaborContractEmployer,
     onSuccess: () => {
-      navigate(`/employer/applicant/${id}/document-detail`);
+      navigate(`/employer/applicant/document-detail/${id}`);
     },
     onError: () =>
       navigate('/write-documents', {

--- a/src/pages/WriteDocuments/DocumentPreviewPage.tsx
+++ b/src/pages/WriteDocuments/DocumentPreviewPage.tsx
@@ -83,7 +83,9 @@ const DocumentPreview = () => {
       <BaseHeader
         hasBackButton={true}
         hasMenuButton={true}
-        title="Fill in document"
+        title={account_type === 'OWNER'
+          ? `문서 미리보기`
+          : `Document Preview`}
         onClickBackButton={() =>
           navigate(
             account_type === 'OWNER'

--- a/src/pages/WriteDocuments/DocumentPreviewPage.tsx
+++ b/src/pages/WriteDocuments/DocumentPreviewPage.tsx
@@ -18,11 +18,13 @@ import EmployeeInfoSection from '@/components/Document/write/EmployeeInfoSection
 import InfoAlert from '@/components/Document/write/InfoAlert';
 import IntegratedApplicationPreview from '@/components/Document/write/IntegratedApplicationPreview';
 import { useCurrentDocumentIdStore } from '@/store/url';
+import { useUserStore } from '@/store/user';
 
 const DocumentPreview = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { currentDocumentId } = useCurrentDocumentIdStore();
+  const { account_type } = useUserStore();
   const { type } = location.state || {};
   const [document, setDocument] = useState<
     PartTimePermitData | LaborContractDataResponse | IntegratedApplicationData
@@ -83,7 +85,11 @@ const DocumentPreview = () => {
         hasMenuButton={true}
         title="Fill in document"
         onClickBackButton={() =>
-          navigate(`/application-documents/${currentDocumentId}`)
+          navigate(
+            account_type === 'OWNER'
+              ? `/employer/applicant/document-detail/${currentDocumentId}`
+              : `/application-documents/${currentDocumentId}`,
+          )
         }
       />
       <DocumentSubHeader type={type as DocumentType} />

--- a/src/types/api/document.ts
+++ b/src/types/api/document.ts
@@ -210,7 +210,9 @@ export type LaborContractEmployerInfo = {
 // 근로계약서 고용주 정보 속성명 enum
 export enum LaborContractEmployerInfoProperty {
   COMPANY_NAME = 'company_name',
+  COMPANY_REGISTRATION_NUMBER = 'company_registration_number',
   NAME = 'name',
+  PHONE_NUMBER = 'phone_number',
   START_DATE = 'start_date', // yyyy-MM-dd format
   END_DATE = 'end_date', // yyyy-MM-dd format
   ADDRESS = 'address',

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -1,11 +1,13 @@
 import {
   EmployerInformation,
+  Insurance,
   IntegratedApplicationData,
   LaborContractEmployerInfo,
   WorkDayTime,
 } from '@/types/api/document';
 import { Address } from '@/types/api/users';
 import { extractNumbersAsNumber } from './post';
+import { InsuranceInfo } from '@/constants/documents';
 
 // 객체의 모든 프로퍼티가 공백이 아닌지 확인하는 함수
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -214,7 +216,8 @@ export const validateIntegratedApplication = (
   // 이메일 검사
   const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
   if (!emailRegex.test(data.email)) {
-    return false;}
+    return false;
+  }
 
   // 사업자등록번호 유효성 검사 (000/00/00000) 양식
   const companyRegistrationNumPattern = /^\d{3}\/\d{2}\/\d{5}$/;
@@ -240,4 +243,21 @@ export const validateIntegratedApplication = (
   });
 
   return isAddressValid && isIncomeValid && otherFieldsValid;
+};
+
+// 보험 이름과 enum 매핑 함수
+export const getInsuranceByName = (name: string): Insurance | undefined => {
+  const entry = Object.entries(InsuranceInfo).find(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ([_, value]) => value.name === name,
+  );
+  return entry ? (entry[0] as Insurance) : undefined;
+};
+
+export const getInsuranceByKey = (key: string): Insurance | undefined => {
+  const entry = Object.entries(InsuranceInfo).find(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ([_, value]) => value.key === key,
+  );
+  return entry ? (entry[0] as Insurance) : undefined;
 };

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -152,6 +152,12 @@ export const validateLaborContractEmployerInformation = (
     return false;
   }
 
+  // 주휴일 체크
+  if (!info.weekly_last_days || info.weekly_last_days.length === 0) {
+    console.log('주휴일');
+    return false;
+  }
+
   // 서명 체크
   if (!info.signature_base64 || info.signature_base64 === '') {
     console.log('서명');


### PR DESCRIPTION
## Related issue 🛠

#127 


## Work Description ✏️

- 작업 내용
- 고용주/유학생 서류 작성 과정 중 잔존 에러 및 UI 오류 수정
  - 서류 카드 적색 점 위치 ui 깨짐 현상 수정
  - 고용주 근로계약서 미리보기 연결(현재 고용주가 작성한 후 미리보기 시 서버 에러 발생)
  - 고용주/유학생 뒤로가기 url 변동 적용
  - 월급일 입력 Input prefix ui 줄 바꿈 현상 수정
  - 고용주 근로계약서 작성 후 리다이렉트 경로 정정
  - 유학생이 입력한 정보 중 서명 미리보기가 정상적으로 표기되도록 수정
  - 보험 선택 시 enum으로 입력되도록 수정
  - 고용주 근로계약서 미리보기 관련 업데이트 된 api 명세서 type 적용
## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] 근로계약서 미리보기 관련 서버 에러 발생으로 이후 submit과 confirm 테스트 대기 상태

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
