### PR TITLE
[Fix/IGW-62/137] expo 웹뷰 폰트 오류를 해결하기 위해 ttf 폰트 포맷도 추가로 적용하기

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,9 @@
 
 @font-face {
   font-family: 'Pretendard';
-  src: url('/src/assets/fonts/PretendardVariable.woff2') format('woff2');
+  src:
+    url('/src/assets/fonts/PretendardVariable.woff2') format('woff2'),
+    url('/src/assets/fonts/PretendardVariable.ttf') format('truetype');
   font-display: 'fallback';
 }
 


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #137

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- expo 웹뷰 폰트 오류를 해결하기 위해 ttf 폰트 포맷도 추가로 적용하기

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Task1

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

woff2 파일이 네이티브 환경에서 지원되지 않을 수 있으므로 ttf 포맷도 추가해보았다! 근데 이거 문제가 아닌 것 같다...
