### PR TITLE
[Fix/igw 65/145] JWT 토큰 재발급/회원가입 리디자인 반영

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -14,6 +14,7 @@ import {
 import { api } from '@/api/index.ts';
 import { apiWithoutAuth } from '@/api/index.ts';
 import { RESTYPE } from '@/types/api/common';
+import axios from 'axios';
 
 /**
  * 사용자 로그인을 처리하는 함수
@@ -50,8 +51,24 @@ export const logout = async (): Promise<RESTYPE<null>> => {
 };
 
 // 1.3 JWT 재발급
-export const reIssueToken = async (): Promise<RESTYPE<SignInResponse>> => {
-  const response = await api.post('/auth/reissue/token');
+// (1) refresh token을 헤더에 포함하여 axios instance 생성
+const apiWithRefreshToken = axios.create({
+  baseURL: import.meta.env.VITE_APP_API_GIGGLE_API_BASE_URL, // 기본 URL을 api와 동일하게 설정
+});
+// (2) 재발급 api 호출
+export const reIssueToken = async (
+  refreshToken: string,
+): Promise<RESTYPE<SignInResponse>> => {
+  //
+  const response = await apiWithRefreshToken.post(
+    '/auth/reissue/token',
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+      },
+    },
+  );
   return response.data;
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,21 @@
-import { getAccessToken } from '@/utils/auth';
+import {
+  getAccessToken,
+  getRefreshToken,
+  setAccessToken,
+  setRefreshToken,
+} from '@/utils/auth';
 import axios, { AxiosInstance } from 'axios';
+import { reIssueToken } from '@/api/auth';
+
+// 리다이렉션 처리 함수 (전역)
+let redirectToSignin: () => void = () => {
+  console.warn('리다이렉션 함수가 설정되지 않았습니다.');
+};
+
+// 리다이렉션 함수 설정
+export function setRedirectToLogin(callback: () => void) {
+  redirectToSignin = callback;
+}
 
 /**
  * Axios 인스턴스에 인터셉터를 설정하는 함수
@@ -31,6 +47,80 @@ function setInterceptors(instance: AxiosInstance, type: string) {
     },
   );
 
+  /**
+   * api instance의 반환값에 대한 처리
+   *
+   * 에러코드 40101이 반환되었을 경우,
+   * access token 만료되어 refresh token으로 토큰 재발행이 필요합니다.
+   *
+   * 반환되는 에러 참고 - error: {code: 40101, message: "만료된 토큰입니다."}
+   */
+  let isTokenRefreshing = false;
+  let failedRequestsQueue: any[] = [];
+
+  instance.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      if (error.response && error.response.status === 401) {
+        if (error.response.data.error.code === 40101) {
+          console.log('401');
+
+          const refreshToken = getRefreshToken();
+
+          if (!refreshToken) {
+            console.error('Refresh Token이 없습니다.');
+            setAccessToken(null);
+            setRefreshToken(null);
+            redirectToSignin();
+            return Promise.reject('Refresh Token이 없습니다.');
+          }
+
+          // 토큰 재발급 중인 상태일 때
+          if (isTokenRefreshing) {
+            // 재발급이 완료될 때까지 대기하고, 완료 후 요청을 재시도
+            return new Promise((resolve, reject) => {
+              failedRequestsQueue.push({ resolve, reject });
+            });
+          }
+
+          // JWT 재발급
+          try {
+            // 토큰 재발급 시작
+            isTokenRefreshing = true;
+
+            // 1. Refresh Token을 사용하여 새로운 Access Token 발급
+            const response = await reIssueToken(refreshToken);
+            const access_token = response.data.access_token;
+            const refresh_token = response.data.refresh_token;
+
+            // 2. 새로운 Access Token, Refresh Token 저장
+            setAccessToken(access_token);
+            setRefreshToken(refresh_token);
+
+            // 3. 모든 대기 중인 요청을 새로운 Access Token과 함께 처리
+            failedRequestsQueue.forEach((request: any) => request.resolve()); // 요청 재시도
+            failedRequestsQueue = []; // 큐 비우기
+
+            // 4. 원래 요청을 새로운 Access Token과 함께 재시도
+            error.config.headers['Authorization'] = `Bearer ${access_token}`;
+            return instance.request(error.config); // 재시도
+          } catch (e) {
+            // 재발급 실패 시
+            console.error('토큰 재발급 실패:', e);
+            // 토큰 초기화 및 로그인 페이지로 이동
+            setAccessToken(null);
+            setRefreshToken(null);
+            redirectToSignin(); // 로그인 페이지로 이동
+            // 실패한 요청 큐 에러 처리
+            failedRequestsQueue.forEach((request: any) => request.reject(e)); // 실패한 요청들에 대해 에러 처리
+            failedRequestsQueue = [];
+            return Promise.reject(e);
+          }
+        }
+      }
+      return Promise.reject(error);
+    },
+  );
   return instance;
 }
 

--- a/src/components/Signin/SigninInputSection.tsx
+++ b/src/components/Signin/SigninInputSection.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { validateId, validatePassword } from '@/utils/signin';
 import { useSignIn } from '@/hooks/api/useAuth';
 import { useUserInfoforSigninStore } from '@/store/signup';
+import BottomButtonPanel from '../Common/BottomButtonPanel';
 
 const SigninInputSection = () => {
   const navigate = useNavigate();
@@ -57,8 +58,8 @@ const SigninInputSection = () => {
   }, [idValue, passwordValue]);
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="w-[20.5rem] flex flex-col gap-4">
+    <div className="w-full px-6 flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
         <div>
           <p className="py-2 px-1 text-sm font-normal text-[#171719]">ID</p>
           <Input
@@ -94,28 +95,30 @@ const SigninInputSection = () => {
         </button>
         */}
       </div>
-      <div className="py-6 flex flex-col items-center gap-2">
-        <Button
-          type="large"
-          bgColor={isValid ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'}
-          fontColor={isValid ? 'text-[#1E1926]' : 'text-[#BDBDBD]'}
-          isBorder={false}
-          title="Sign In"
-          onClick={isValid ? handleSubmit : undefined}
-        />
-        <div className="flex items-center justify-center gap-2">
-          <p className="text-[#7D8A95] text-sm font-normal">
-            Don't have an account?
-          </p>
-          {/* 회원가입 화면 이동 */}
-          <button
-            className="text-[#7872ED] text-sm font-semibold"
-            onClick={() => navigate('/signup')}
-          >
-            Create Account
-          </button>
+      <BottomButtonPanel>
+        <div className="w-full flex flex-col items-center gap-2">
+          <div className="flex items-center justify-center gap-2">
+            <p className="text-[#7D8A95] text-sm font-normal">
+              Don't have an account?
+            </p>
+            {/* 회원가입 화면 이동 */}
+            <button
+              className="text-[#000] text-sm font-semibold"
+              onClick={() => navigate('/signup')}
+            >
+              Create Account
+            </button>
+          </div>
+          <Button
+            type="large"
+            bgColor={isValid ? 'bg-[#000]' : 'bg-[#F4F4F9]'}
+            fontColor={isValid ? 'text-[#FEF387]' : 'text-[#BDBDBD]'}
+            isBorder={false}
+            title="Sign In"
+            onClick={isValid ? handleSubmit : undefined}
+          />
         </div>
-      </div>
+      </BottomButtonPanel>
     </div>
   );
 };

--- a/src/components/Signin/SigninInputSection.tsx
+++ b/src/components/Signin/SigninInputSection.tsx
@@ -96,7 +96,7 @@ const SigninInputSection = () => {
         */}
       </div>
       <BottomButtonPanel>
-        <div className="w-full flex flex-col items-center gap-2">
+        <div className="w-full flex flex-col items-center gap-6">
           <div className="flex items-center justify-center gap-2">
             <p className="text-[#7D8A95] text-sm font-normal">
               Don't have an account?

--- a/src/components/Signup/EmailInput.tsx
+++ b/src/components/Signup/EmailInput.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import Input from '@/components/Common/Input';
 import Button from '@/components/Common/Button';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { validateEmail } from '@/utils/signin';
 import { signInputTranclation } from '@/constants/translation';
 import { isEmployer } from '@/utils/signup';
 import { useGetEmailValidation } from '@/hooks/api/useAuth';
+import BottomButtonPanel from '../Common/BottomButtonPanel';
 
 type EmailInputProps = {
   email: string;
@@ -14,7 +15,6 @@ type EmailInputProps = {
 };
 
 const EmailInput = ({ email, onEmailChange, onSubmit }: EmailInputProps) => {
-  const navigate = useNavigate();
   const { pathname } = useLocation();
   const [emailError, setEmailError] = useState<string | null>(null);
   const [isValid, setIsValid] = useState<boolean>(false);
@@ -56,9 +56,9 @@ const EmailInput = ({ email, onEmailChange, onSubmit }: EmailInputProps) => {
   };
 
   return (
-    <>
-      <div className="title-1 text-center py-6">
-        {signInputTranclation.signup[isEmployer(pathname)]}
+    <div className="w-full">
+      <div className="title-1 pb-12">
+        {signInputTranclation.enterEmail[isEmployer(pathname)]}
       </div>
       <div className="w-[20.5rem] flex flex-col py-6">
         <div>
@@ -78,33 +78,19 @@ const EmailInput = ({ email, onEmailChange, onSubmit }: EmailInputProps) => {
           )}
         </div>
       </div>
-      <div className="py-6 flex flex-col items-center gap-2 absolute bottom-[16%]">
-        <Button
-          type="large"
-          bgColor={isValid ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'}
-          fontColor={isValid ? 'text-[#1E1926]' : 'text-[#BDBDBD]'}
-          isBorder={false}
-          title={signInputTranclation.continue[isEmployer(pathname)]}
-          onClick={isValid ? handleSignupClick : undefined}
-        />
-        <div className="flex items-center justify-center gap-2 pb-2">
-          <p className="text-[#7D8A95] text-sm font-normal">
-            {signInputTranclation.haveAccount[isEmployer(pathname)]}
-          </p>
-          {/* 로그인 화면 이동 */}
-          <button
-            className="text-[#7872ED] text-sm font-semibold"
-            onClick={() => navigate('/signin')}
-          >
-            {signInputTranclation.signin[isEmployer(pathname)]}
-          </button>
+      <BottomButtonPanel>
+        <div className="w-full">
+          <Button
+            type="large"
+            bgColor={isValid ? 'bg-[#1E1926]' : 'bg-[#F4F4F9]'}
+            fontColor={isValid ? 'text-[#FEF387]' : 'text-[#BDBDBD]'}
+            isBorder={false}
+            title={signInputTranclation.continue[isEmployer(pathname)]}
+            onClick={isValid ? handleSignupClick : undefined}
+          />
         </div>
-        {/* 소셜은 잠깐 제외 */}
-        {/* 
-        <SigninSocialButtons />
-        */}
-      </div>
-    </>
+      </BottomButtonPanel>
+    </div>
   );
 };
 

--- a/src/components/Signup/EmailInput.tsx
+++ b/src/components/Signup/EmailInput.tsx
@@ -60,7 +60,7 @@ const EmailInput = ({ email, onEmailChange, onSubmit }: EmailInputProps) => {
       <div className="title-1 pb-12">
         {signInputTranclation.enterEmail[isEmployer(pathname)]}
       </div>
-      <div className="w-[20.5rem] flex flex-col py-6">
+      <div className="flex flex-col py-6">
         <div>
           <p className="py-2 px-1 text-sm font-normal text-[#171719]">
             {signInputTranclation.email[isEmployer(pathname)]}

--- a/src/components/Signup/FindJourney.tsx
+++ b/src/components/Signup/FindJourney.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/Common/Button';
 import { cardData, UserType } from '@/constants/user';
+import BottomButtonPanel from '../Common/BottomButtonPanel';
 
 type findJourneyProps = {
   onSignUpClick: () => void;
@@ -17,20 +18,23 @@ const FindJourney = ({
   };
 
   return (
-    <div className="w-full h-full flex flex-col items-center justify-center">
-      <div className="w-full">
-        <div className="title-1">Find Your Journey</div>
+    <div className="w-full h-full flex flex-col items-center">
+      <div className="flex flex-col w-full gap-1">
+        <div className="title-1">
+          기글에 오신 것을 <br />
+          환영해요!
+        </div>
         <div className="body-1">당신에게 알맞는 정보를 드릴게요!</div>
       </div>
-      <div className="flex gap-2.5 py-6">
+      <div className="w-full flex flex-col gap-2.5 py-6">
         {/* 유학생, 고용주 타입 선택 카드 */}
         {cardData.map((card) => (
           <div
             key={card.accountType}
-            className={`flex flex-col justify-end gap-1.5 h-[12.5rem] w-[10rem] p-[1.125rem] bg-cover bg-yellow-100 border-[0.5px] border-[#f2f2f2] rounded-[1.25rem] ${
+            className={`w-full py-6 px-[1.125rem] flex flex-col justify-end gap-1.5 rounded-[1.25rem] ${
               accountType === card.accountType
-                ? 'bg-[url("/src/assets/images/yellowCard.png")] shadow-yellowShadow '
-                : ''
+                ? 'bg-[#FEF387] shadow-md'
+                : 'bg-yellow-100'
             }`}
             onClick={() => handleClick(card.accountType)}
           >
@@ -41,14 +45,16 @@ const FindJourney = ({
       </div>
       <div className="py-6 w-full">
         {/* 타입 선택 후에 Sign Up 가능 */}
-        <Button
-          type="large"
-          bgColor={accountType ? 'bg-[#1E1926]' : 'bg-[#F4F4F9]'}
-          fontColor={accountType ? 'text-[#FEF387]' : 'text-[#BDBDBD]'}
-          isBorder={false}
-          title="Sign Up"
-          onClick={accountType ? onSignUpClick : undefined}
-        />
+        <BottomButtonPanel>
+          <Button
+            type="large"
+            bgColor={accountType ? 'bg-[#1E1926]' : 'bg-[#F4F4F9]'}
+            fontColor={accountType ? 'text-[#FEF387]' : 'text-[#BDBDBD]'}
+            isBorder={false}
+            title="Sign Up"
+            onClick={accountType ? onSignUpClick : undefined}
+          />
+        </BottomButtonPanel>
       </div>
     </div>
   );

--- a/src/components/Signup/SignupInput.tsx
+++ b/src/components/Signup/SignupInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Input from '@/components/Common/Input';
 import Button from '@/components/Common/Button';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import {
   validatedConfirmPassword,
   validateId,
@@ -10,6 +10,7 @@ import {
 import { isEmployer } from '@/utils/signup';
 import { signInputTranclation } from '@/constants/translation';
 import { useGetIdValidation } from '@/hooks/api/useAuth';
+import BottomButtonPanel from '../Common/BottomButtonPanel';
 
 type signupInputProps = {
   id: string;
@@ -26,7 +27,6 @@ const SignupInput = ({
   onIdChange,
   onPasswordChange,
 }: signupInputProps) => {
-  const navigate = useNavigate();
   const { pathname } = useLocation();
 
   // // ===== state =====
@@ -102,12 +102,12 @@ const SignupInput = ({
   };
 
   return (
-    <>
-      <div className="title-1 text-center py-6">
+    <div className="w-full">
+      <div className="title-1 pb-12">
         {signInputTranclation.signup[isEmployer(pathname)]}
       </div>
       <div className="flex flex-col gap-2">
-        <div className="w-[20.5rem] flex flex-col">
+        <div className="flex flex-col">
           <div>
             <p className="py-2 px-1 body-2 text-[#656565]">
               {signInputTranclation.id[isEmployer(pathname)]}
@@ -163,34 +163,24 @@ const SignupInput = ({
             )}
           </div>
         </div>
-        <div className="py-6 flex flex-col items-center gap-2">
-          <Button
-            type="large"
-            bgColor={isValid ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'}
-            fontColor={isValid ? 'text-[#1E1926]' : 'text-[#BDBDBD]'}
-            isBorder={false}
-            title={signInputTranclation.continue[isEmployer(pathname)]}
-            onClick={isValid ? onSignUpClick : undefined}
-          />
-          <div className="flex items-center justify-center gap-2">
-            <p className="text-[#7D8A95] body-2">
-              {signInputTranclation.haveAccount[isEmployer(pathname)]}
-            </p>
-            {/* 로그인 화면 이동 */}
-            <button
-              className="text-[#7872ED] text-sm font-semibold"
-              onClick={() => navigate('/signin')}
-            >
-              {signInputTranclation.signin[isEmployer(pathname)]}
-            </button>
+        <BottomButtonPanel>
+          <div className="w-full">
+            <Button
+              type="large"
+              bgColor={isValid ? 'bg-[#1E1926]' : 'bg-[#F4F4F9]'}
+              fontColor={isValid ? 'text-[#FEF387]' : 'text-[#BDBDBD]'}
+              isBorder={false}
+              title={signInputTranclation.continue[isEmployer(pathname)]}
+              onClick={isValid ? onSignUpClick : undefined}
+            />
           </div>
-        </div>
+        </BottomButtonPanel>
       </div>
       {/* 소셜은 잠깐 제외 */}
       {/* 
       <SigninSocialButtons />
       */}
-    </>
+    </div>
   );
 };
 

--- a/src/components/Signup/SignupVerification.tsx
+++ b/src/components/Signup/SignupVerification.tsx
@@ -174,17 +174,19 @@ const SignupVerification = ({
         </div>
         {/* 5회 이내 이메일 재발송 가능 */}
         {!resendDisabled && (
-          <div className="absolute top-[-1.125rem] flex items-center justify-center gap-2">
-            <p className="text-[#7D8A95] text-sm font-normal">
-              {signInputTranclation.requestResend[isEmployer(pathname)]}
-            </p>
-            <button
-              className="text-[#7872ED] text-sm font-semibold"
-              onClick={handleResendClick} // 이메일 인증코드 재전송 API 호출
-            >
-              {signInputTranclation.resend[isEmployer(pathname)]}
-            </button>
-          </div>
+          <>
+            <div className="absolute top-[-1.125rem] flex items-center justify-center gap-2">
+              <p className="text-[#7D8A95] text-sm font-normal">
+                {signInputTranclation.requestResend[isEmployer(pathname)]}
+              </p>
+              <button
+                className="text-[#7872ED] text-sm font-semibold"
+                onClick={handleResendClick} // 이메일 인증코드 재전송 API 호출
+              >
+                {signInputTranclation.resend[isEmployer(pathname)]}
+              </button>
+            </div>
+          </>
         )}
       </BottomButtonPanel>
     </div>

--- a/src/components/Signup/SignupVerification.tsx
+++ b/src/components/Signup/SignupVerification.tsx
@@ -138,7 +138,7 @@ const SignupVerification = ({
         {signInputTranclation.enterCode[isEmployer(pathname)]}
       </div>
       <div className="py-[3.125rem] flex flex-col gap-8">
-        <div className="flex gap-3">
+        <div className="flex gap-3 justify-center">
           {Array.from({ length: 6 }).map((_, index) => (
             <input
               key={index}

--- a/src/components/Signup/SignupVerification.tsx
+++ b/src/components/Signup/SignupVerification.tsx
@@ -6,6 +6,7 @@ import { isEmployer } from '@/utils/signup';
 import { useLocation } from 'react-router-dom';
 import { useEmailTryCountStore } from '@/store/signup';
 import { useReIssueAuthentication } from '@/hooks/api/useAuth';
+import BottomButtonPanel from '../Common/BottomButtonPanel';
 
 type SignupVerificationProps = {
   email: string;
@@ -126,7 +127,10 @@ const SignupVerification = ({
   };
 
   return (
-    <div>
+    <div className="w-full">
+      <div className="title-1 pb-12">
+        {signInputTranclation.almost[isEmployer(pathname)]}
+      </div>
       <div className="title-1 text-center pt-6 pb-2">
         {signInputTranclation.verification[isEmployer(pathname)]}
       </div>
@@ -156,11 +160,13 @@ const SignupVerification = ({
         {resendMessage && (
           <div className="button-2 text-[#7872ED]">{resendMessage}</div>
         )}
-        <div className="w-full px-6">
+      </div>
+      <BottomButtonPanel>
+        <div className="w-full relative">
           <Button
             type="large"
-            bgColor={isValid ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'}
-            fontColor={isValid ? 'text-[#1E1926]' : 'text-[#BDBDBD]'}
+            bgColor={isValid ? 'bg-[#1E1926]' : 'bg-[#F4F4F9]'}
+            fontColor={isValid ? 'text-[#FEF387]' : 'text-[#BDBDBD]'}
             isBorder={false}
             title={signInputTranclation.verify[isEmployer(pathname)]}
             onClick={isValid ? handleVerifyClick : undefined}
@@ -168,7 +174,7 @@ const SignupVerification = ({
         </div>
         {/* 5회 이내 이메일 재발송 가능 */}
         {!resendDisabled && (
-          <div className="flex items-center justify-center gap-2">
+          <div className="absolute top-[-1.125rem] flex items-center justify-center gap-2">
             <p className="text-[#7D8A95] text-sm font-normal">
               {signInputTranclation.requestResend[isEmployer(pathname)]}
             </p>
@@ -180,7 +186,7 @@ const SignupVerification = ({
             </button>
           </div>
         )}
-      </div>
+      </BottomButtonPanel>
     </div>
   );
 };

--- a/src/components/Splash/Splash.tsx
+++ b/src/components/Splash/Splash.tsx
@@ -45,7 +45,7 @@ const Splash = () => {
 
         if (!access && refresh) {
           if (userTypeResponse?.error?.code === 401) {
-            reIssueToken();
+            reIssueToken(refresh);
           } else {
             setGuest();
           }
@@ -62,7 +62,7 @@ const Splash = () => {
           }
         }
       } catch (error) {
-        console.error(error)
+        console.error(error);
         alert('로그인 오류입니다 다시 시도해주세요');
         setGuest();
       } finally {

--- a/src/constants/translation.ts
+++ b/src/constants/translation.ts
@@ -4,8 +4,8 @@ export const signInputTranclation = {
     en: 'Sign In',
   },
   signup: {
-    ko: '회원가입',
-    en: 'Sign Up',
+    ko: '아이디와 비밀번호를 입력해주세요',
+    en: 'Enter your ID and Password',
   },
   id: {
     ko: '아이디',
@@ -60,7 +60,7 @@ export const signInputTranclation = {
     en: 'Email Address',
   },
   enterEmail: {
-    ko: '이메일을 입력해주세요',
+    ko: '인증을 위해 이메일을 입력해주세요',
     en: 'Enter email address',
   },
   invalidEmail: {
@@ -74,6 +74,10 @@ export const signInputTranclation = {
   verification: {
     ko: '인증번호',
     en: 'Verification',
+  },
+  almost: {
+    ko: '거의 다했어요!',
+    en: 'Almost done!',
   },
   enterCode: {
     ko: '입력하신 이메일로 인증번호를 전송하였습니다.',

--- a/src/pages/Signin/SigninPage.tsx
+++ b/src/pages/Signin/SigninPage.tsx
@@ -1,8 +1,8 @@
+import BaseHeader from '@/components/Common/Header/BaseHeader';
 import SigninInputSection from '@/components/Signin/SigninInputSection';
 import { useUserStore } from '@/store/user';
 import { deleteAccessToken, deleteRefreshToken } from '@/utils/auth';
 import { useEffect } from 'react';
-import CloseIcon from '@/assets/icons/CloseIcon.svg?react';
 import { useNavigate } from 'react-router-dom';
 
 const SigninPage = () => {
@@ -19,14 +19,20 @@ const SigninPage = () => {
   }, []);
 
   return (
-    <div className="h-[100vh] flex flex-col justify-center items-center px-7">
-      <CloseIcon
-        onClick={() => navigate('/')}
-        className="fixed top-6 right-6"
+    <div className="h-screen flex flex-col justify-center items-center">
+      <BaseHeader
+        hasBackButton={true}
+        hasMenuButton={false}
+        title="Sign In"
+        onClickBackButton={() => navigate('/')}
       />
-      <div className="text-[#1E1926] text-[1.75rem] font-semibold">Sign In</div>
-      <SigninInputSection />
-      {/* <SigninSocialButtons /> */}
+      <div className="w-full flex-grow flex flex-col">
+        <div className="flex items-start mx-6 my-[3.125rem] h-[5rem] text-[#1E1926] text-[1.75rem] font-semibold">
+          이메일로 로그인
+        </div>
+        <SigninInputSection />
+        {/* <SigninSocialButtons /> */}
+      </div>
     </div>
   );
 };

--- a/src/pages/Signup/SignupPage.tsx
+++ b/src/pages/Signup/SignupPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import FindJourney from '@/components/Signup/FindJourney';
-import Stroke from '@/assets/icons/SignupStroke.svg?react';
 import SignupInput from '@/components/Signup/SignupInput';
 import { UserType } from '@/constants/user';
 import EmailInput from '@/components/Signup/EmailInput';
@@ -10,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { usePatchAuthentication, useTempSignUp } from '@/hooks/api/useAuth';
 import { deleteAccessToken, deleteRefreshToken } from '@/utils/auth';
 import { useUserStore } from '@/store/user';
+import BaseHeader from '@/components/Common/Header/BaseHeader';
 
 const SignupPage = () => {
   const navigate = useNavigate();
@@ -30,6 +30,12 @@ const SignupPage = () => {
   // mutate 관리
   const { mutate: tempSignUp } = useTempSignUp();
   const { mutate: verifyAuthCode } = usePatchAuthentication();
+
+  // back 버튼 핸들러
+  const handleBackButtonClick = () => {
+    if (currentStep <= 1) navigate('/signin');
+    if (currentStep > 1 && currentStep < 5) setCurrentStep(currentStep - 1);
+  };
 
   // handler 정의
   const handleSignUpClick = () => {
@@ -81,19 +87,40 @@ const SignupPage = () => {
   }, []);
 
   return (
-    <div
-      className={`flex flex-col w-[100vw] h-[100vh] ${currentStep == 1 ? `bg-[#FEF387]` : 'bg-white'} `}
-    >
+    <div className="flex flex-col w-screen h-screen bg-white">
+      <BaseHeader
+        hasBackButton={true}
+        onClickBackButton={() => handleBackButtonClick()}
+        hasMenuButton={false}
+        title="Sign Up"
+      />
       {currentStep === 5 ? (
         <VerificationSuccessful />
       ) : (
-        <div className="flex justify-center items-center gap-3 pt-6 pr-8 pb-[3.125rem] pl-8">
-          <Stroke stroke={currentStep === 1 ? '#1E1926' : '#FFF'} />
-          <Stroke stroke={currentStep === 2 ? '#1E1926' : '#FFF'} />
-          <Stroke stroke={currentStep === 3 ? '#1E1926' : '#FFF'} />
-          <Stroke stroke={currentStep === 4 ? '#1E1926' : '#FFF'} />
+        <div className="w-screen flex justify-center items-center pt-6 pb-[3.125rem]">
+          <hr
+            className={`w-[25%] h-1 border-0 ${
+              currentStep >= 1 ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'
+            }`}
+          />
+          <hr
+            className={`w-[25%] h-1 border-0 ${
+              currentStep >= 2 ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'
+            }`}
+          />
+          <hr
+            className={`w-[25%] h-1 border-0 ${
+              currentStep >= 3 ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'
+            }`}
+          />
+          <hr
+            className={`w-[25%] h-1 border-0 ${
+              currentStep === 4 ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'
+            }`}
+          />
         </div>
       )}
+      {/* 회원가입 STEP 별 랜딩 컴포넌트 */}
       <div className="grow px-6 flex flex-col items-center">
         {currentStep === 1 && (
           <FindJourney

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { Outlet, useLocation } from 'react-router-dom';
 import { useUserStore } from '@/store/user';
 import { UserType } from '@/constants/user';
@@ -49,10 +49,23 @@ import ApplicantDocumentsDetailPage from '@/pages/Employer/WriteDocuments/Applic
 import EmployerWriteDocumentsPage from '@/pages/Employer/WriteDocuments/EmployerWriteDocumentsPage';
 import EmployerEditPostPage from './pages/Employer/Post/EmployerEditPostPage';
 import PostSearchFilterPage from '@/pages/PostSearch/PostSearchFilterPage';
+import { useEffect } from 'react';
+import { setRedirectToLogin } from '@/api';
 
 const Layout = () => {
+  // -- 1. 토큰의 만료, 혹은 토큰이 없을 경우의 트리거 --
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setRedirectToLogin(() => {
+      navigate('/signin');
+    });
+  }, [navigate]);
+
+  // -- 2. Nav bar 조건부 랜딩 로직 --
   const location = useLocation();
   const { account_type } = useUserStore();
+
   // Nav bar 컴포넌트가 랜딩되는 페이지
   const showNavbarPaths = () => {
     if (account_type === UserType.OWNER) {


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #145 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- access token이 만료되었을 때, refresh token으로 JWT 토큰 재발급
(1) access token 401 에러 코드 인터셉트
(2) refresh token이 있는 경우, JWT 토큰 재발급 api 수행
(3) 그 사이에 401 에러로 반환된 요청을 큐에 저장
(4) JWT 토큰 재발급이 완료되면 큐에 있는 요청을 재실행
<img src="https://github.com/user-attachments/assets/5e6f7b85-1d59-4a41-8ab4-6ca16de80d2a" width="600" height="550" />

- 회원가입 리디자인 반영(뒤로가기 추가)
<img src="https://github.com/user-attachments/assets/18400c1d-c270-465f-bfb7-c125731a5ab1" width="300" />


## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Personal Information 수정 기능 추가 (디자인 작업 중)

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
