### PR TITLE
feat/99 - 약관동의, 상세조회

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,7 @@
 import {
   AuthenticationRequest,
   AuthenticationResponse,
+  PolicyResponse,
   ReIssueAuthenticationRequest,
   SignInRequest,
   SignInResponse,
@@ -15,6 +16,7 @@ import { api } from '@/api/index.ts';
 import { apiWithoutAuth } from '@/api/index.ts';
 import { RESTYPE } from '@/types/api/common';
 import axios from 'axios';
+import { TermType } from '@/types/api/users';
 
 /**
  * 사용자 로그인을 처리하는 함수
@@ -147,5 +149,13 @@ export const signUpEmployer = async (
   signupInfo: FormData,
 ): Promise<RESTYPE<SignUpResponse>> => {
   const response = await api.post(`/auth/owners`, signupInfo);
+  return response.data;
+};
+
+// 11.1 약관 상세조회
+export const getPolicy = async (
+  termType: TermType,
+): Promise<RESTYPE<PolicyResponse>> => {
+  const response = await api.get(`/terms/${termType}/details`);
   return response.data;
 };

--- a/src/components/Employer/Signup/AgreeModalInner.tsx
+++ b/src/components/Employer/Signup/AgreeModalInner.tsx
@@ -1,16 +1,21 @@
 import CheckIcon from '@/assets/icons/CheckOfBoxIcon.svg?react';
 import ArrowIcon from '@/assets/icons/RightArrowIcon.svg?react';
 import Button from '@/components/Common/Button';
+import { TermType } from '@/types/api/users';
 import { Dispatch, SetStateAction, useState } from 'react';
 
 type AgreeModalInnerProps = {
   setMarketingAllowed: (value: boolean) => void;
+  onPolicyPreview: (termType: TermType) => void;
   onNext: Dispatch<SetStateAction<boolean>>;
+  accountType: 'USER' | 'EMPLOYER';
 };
 
 const AgreeModalInner = ({
   setMarketingAllowed,
+  onPolicyPreview,
   onNext,
+  accountType,
 }: AgreeModalInnerProps) => {
   const [essentialAgreeList, setEssentialAgreeList] = useState<boolean[]>([
     false,
@@ -76,7 +81,17 @@ const AgreeModalInner = ({
               <div className="w-full flex items-center">
                 (필수) 서비스 이용약관동의
               </div>
-              <ArrowIcon />
+              <div
+                onClick={() =>
+                  onPolicyPreview(
+                    accountType === 'USER'
+                      ? TermType.PERSONAL_SERVICE_TERMS
+                      : TermType.ENTERPRISE_SERVICE_TERMS,
+                  )
+                }
+              >
+                <ArrowIcon />
+              </div>
             </div>
           </div>
           <div className="w-full flex items-center justify-center gap-3">
@@ -92,7 +107,9 @@ const AgreeModalInner = ({
               <div className="w-full flex items-center">
                 (필수) 개인정보 수집 및 이용 동의
               </div>
-              <ArrowIcon />
+              <div onClick={() => onPolicyPreview(TermType.PRIVACY_POLICY)}>
+                <ArrowIcon />
+              </div>
             </div>
           </div>
           <div className="w-full flex items-center justify-center gap-3">
@@ -108,7 +125,11 @@ const AgreeModalInner = ({
               <div className="w-full flex items-center">
                 (필수) 위치정보 이용동의
               </div>
-              <ArrowIcon />
+              <div
+                onClick={() => onPolicyPreview(TermType.LOCATION_BASED_TERMS)}
+              >
+                <ArrowIcon />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/Information/PolicyViewer.tsx
+++ b/src/components/Information/PolicyViewer.tsx
@@ -1,0 +1,66 @@
+import BaseHeader from '../Common/Header/BaseHeader';
+
+const PolicyViewer = ({
+  content,
+  onBack,
+}: {
+  content: string;
+  onBack: () => void;
+}) => {
+  // 2. iframe 사용
+  const renderWithIframe = () => {
+    const responsiveContent = content.replace(
+      '</head>',
+      `<style>
+        :root {
+          /* 기본 폰트 크기 설정 */
+          font-size: calc(12px + 0.4vw);
+        }
+        
+        /* 디바이스 크기별 세부 조정 */
+        @media screen and (max-width: 320px) {
+          :root { font-size: 9px; }
+        }
+        @media screen and (min-width: 768px) {
+          :root { font-size: 16px; }
+        }
+        @media screen and (min-width: 1024px) {
+          :root { font-size: 18px; }
+        }
+  
+        /* 컨텐츠별 상대적 크기 설정 */
+        body { font-size: 1rem; }
+        .version-info { font-size: 0.875rem; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.25rem; }
+        .box { font-size: 1rem; }
+      </style>
+      </head>`,
+    );
+
+    return (
+      <iframe
+        className="w-full h-screen border-0"
+        srcDoc={responsiveContent}
+        title="HTML Content"
+        sandbox="allow-scripts"
+      />
+    );
+  };
+  return (
+    <div className="fixed top-0 w-full h-full space-y-8 z-40 bg-white">
+      <div>
+        <BaseHeader
+          hasBackButton
+          hasMenuButton={false}
+          title="서비스 이용약관 동의"
+          onClickBackButton={onBack}
+        />
+        <div className="w-full border-t border-[#dcdcdc]" />
+        {renderWithIframe()}
+      </div>
+    </div>
+  );
+};
+
+export default PolicyViewer;

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -29,11 +29,16 @@ import {
   setTemporaryToken,
 } from '@/utils/auth';
 import { useNavigate } from 'react-router-dom';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQuery,
+} from '@tanstack/react-query';
 import { useUserInfoforSigninStore } from '@/store/signup';
 import { useEmailTryCountStore } from '@/store/signup';
 import { RESTYPE } from '@/types/api/common';
 import { clearAllStore } from '@/utils/clearAllStore';
+import { TermType } from '@/types/api/users';
 
 /**
  * 로그인 프로세스를 처리하는 커스텀 훅
@@ -266,20 +271,22 @@ export const useWithdraw = () => {
 };
 
 // 11.1 약관 종류별 상세 조회하기
-export const useGetPolicy = ({
-  onSuccess,
-  onError,
-}: {
-  onSuccess?: (data: RESTYPE<PolicyResponse>) => void;
-  onError?: (error: unknown) => void;
-}) => {
-  const { mutate, ...rest } = useMutation({
+export const useGetPolicy = (
+  options?: UseMutationOptions<
+    RESTYPE<PolicyResponse>,
+    Error,
+    TermType // mutationFn의 parameter 타입
+  >,
+) => {
+  return useMutation({
     mutationFn: getPolicy,
-    onSuccess,
-    onError: (error) => {
-      console.error('약관 조회 중 에러 발생:', error);
-      onError?.(error);
+    onSuccess: (data, variables, context) => {
+      options?.onSuccess?.(data, variables, context);
     },
+    onError: (error, variables, context) => {
+      console.error('약관 조회 중 에러 발생:', error);
+      options?.onError?.(error, variables, context);
+    },
+    ...options,
   });
-  return { mutate, ...rest };
 };

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -11,9 +11,11 @@ import {
   tempSignUp,
   withdraw,
   signUpEmployer,
+  getPolicy,
 } from '@/api/auth';
 import {
   AuthenticationResponse,
+  PolicyResponse,
   SignInResponse,
   SignUpResponse,
   TempSignUpResponse,
@@ -261,4 +263,23 @@ export const useWithdraw = () => {
       navigate('/splash');
     },
   });
+};
+
+// 11.1 약관 종류별 상세 조회하기
+export const useGetPolicy = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (data: RESTYPE<PolicyResponse>) => void;
+  onError?: (error: unknown) => void;
+}) => {
+  const { mutate, ...rest } = useMutation({
+    mutationFn: getPolicy,
+    onSuccess,
+    onError: (error) => {
+      console.error('약관 조회 중 에러 발생:', error);
+      onError?.(error);
+    },
+  });
+  return { mutate, ...rest };
 };

--- a/src/pages/Employer/signup/EmployerSignupInfoPage.tsx
+++ b/src/pages/Employer/signup/EmployerSignupInfoPage.tsx
@@ -3,9 +3,11 @@ import BottomSheetLayout from '@/components/Common/BottomSheetLayout';
 import Button from '@/components/Common/Button';
 import CompleteModal from '@/components/Common/CompleteModal';
 import BaseHeader from '@/components/Common/Header/BaseHeader';
+import LoadingItem from '@/components/Common/LoadingItem';
 import AgreeModalInner from '@/components/Employer/Signup/AgreeModalInner';
 import InformationInputSection from '@/components/Employer/Signup/InformationInputSection';
-import { useSignupEmployer } from '@/hooks/api/useAuth';
+import PolicyViewer from '@/components/Information/PolicyViewer';
+import { useGetPolicy, useSignupEmployer } from '@/hooks/api/useAuth';
 import {
   EmployerRegistrationRequestBody,
   initialEmployerRegistration,
@@ -22,7 +24,22 @@ const EmployerSignupInfoPage = () => {
   const [logoFile, setLogoFile] = useState<File | undefined>(undefined);
   const [devIsModal, setDevIsModal] = useState(false);
   const [isAgreeModal, setIsAgreeModal] = useState(true);
+  const [isPolicyPreview, setIsPolicyPreview] = useState(false);
+  const [policy, setPolicy] = useState('');
   const [isValid, setIsValid] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const { mutate: getPolicy } = useGetPolicy({
+    onSuccess: (data) => {
+      setPolicy(data.data.content);
+      setIsPolicyPreview(true);
+    },
+    onMutate: () => {
+      setIsLoading(true);
+    },
+    onSettled: () => {
+      setIsLoading(false);
+    },
+  });
   const { mutate } = useSignupEmployer(() => setDevIsModal(true));
   const navigate = useNavigate();
 
@@ -118,9 +135,28 @@ const EmployerSignupInfoPage = () => {
                 marketing_allowed: value,
               })
             }
+            onPolicyPreview={(policy: TermType) => {
+              getPolicy(policy);
+            }}
             onNext={setIsAgreeModal}
+            accountType="EMPLOYER"
           />
         </BottomSheetLayout>
+      )}
+      {isPolicyPreview === true && (
+        <PolicyViewer
+          content={policy}
+          onBack={() => setIsPolicyPreview(false)}
+        />
+      )}
+      {isLoading && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-white bg-opacity-50 overflow-hidden"
+          style={{ touchAction: 'none' }}
+          onClick={(e) => e.preventDefault()}
+        >
+          <LoadingItem />
+        </div>
       )}
     </div>
   );

--- a/src/pages/Employer/signup/EmployerSignupInfoPage.tsx
+++ b/src/pages/Employer/signup/EmployerSignupInfoPage.tsx
@@ -10,6 +10,7 @@ import {
   EmployerRegistrationRequestBody,
   initialEmployerRegistration,
 } from '@/types/api/employ';
+import { TermType } from '@/types/api/users';
 import { getTemporaryToken } from '@/utils/auth';
 import { isValidEmployerRegistration } from '@/utils/signup';
 import { useEffect, useState } from 'react';
@@ -38,6 +39,11 @@ const EmployerSignupInfoPage = () => {
       const requestData = {
         ...newEmployData,
         temporary_token: String(getTemporaryToken()), // temporary_token 추가
+        term_types: [
+          TermType.ENTERPRISE_SERVICE_TERMS,
+          TermType.LOCATION_BASED_TERMS,
+          TermType.PRIVACY_POLICY,
+        ],
       };
 
       // 이미지 파일이 있는 경우에만 추가

--- a/src/pages/Information/InformationPage.tsx
+++ b/src/pages/Information/InformationPage.tsx
@@ -1,11 +1,13 @@
 import BottomSheetLayout from '@/components/Common/BottomSheetLayout';
 import CompleteModal from '@/components/Common/CompleteModal';
+import LoadingItem from '@/components/Common/LoadingItem';
 import AgreeModalInner from '@/components/Employer/Signup/AgreeModalInner';
 import AddressStep from '@/components/Information/AddressStep';
 import InformationStep from '@/components/Information/InformationStep';
 import LanguageStep from '@/components/Information/LanguageStep';
+import PolicyViewer from '@/components/Information/PolicyViewer';
 import StepIndicator from '@/components/Information/StepIndicator';
-import { useSignUp } from '@/hooks/api/useAuth';
+import { useGetPolicy, useSignUp } from '@/hooks/api/useAuth';
 //import { useSignUp } from '@/hooks/api/useAuth';
 import {
   initialUserInfoRequestBody,
@@ -24,9 +26,24 @@ const InformationPage = () => {
     initialUserInfoRequestBody,
   );
   const [isAgreeModal, setIsAgreeModal] = useState(true);
+  const [isPolicyPreview, setIsPolicyPreview] = useState(false);
+  const [policy, setPolicy] = useState('');
   const [devIsModal, setDevIsModal] = useState(false);
   const [marketingAllowed, setMarketAllowed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const { mutate } = useSignUp(() => setDevIsModal(true));
+  const { mutate: getPolicy } = useGetPolicy({
+    onSuccess: (data) => {
+      setPolicy(data.data.content);
+      setIsPolicyPreview(true);
+    },
+    onMutate: () => {
+      setIsLoading(true);
+    },
+    onSettled: () => {
+      setIsLoading(false);
+    },
+  });
   const navigate = useNavigate();
 
   // 다음 step으로 넘어갈 때 호출되며, 각 step에서 입력한 정보를 userInfo에 저장, 다음 step으로 이동한다.
@@ -41,14 +58,6 @@ const InformationPage = () => {
       TermType.LOCATION_BASED_TERMS,
       TermType.PRIVACY_POLICY,
     ];
-    console.log({
-      ...userInfo,
-      marketing_allowed: marketingAllowed,
-      notification_allowed: false,
-      temporary_token: String(getTemporaryToken()),
-      language: language,
-      term_types: termTypes,
-    })
     mutate({
       ...userInfo,
       marketing_allowed: marketingAllowed,
@@ -57,7 +66,6 @@ const InformationPage = () => {
       language: language,
       term_types: termTypes,
     });
-
   };
   return (
     <div className="m-auto max-w-[500px] relative h-screen flex flex-col items-center justify-start border border-black overflow-y-scroll scrollbar-hide">
@@ -97,9 +105,28 @@ const InformationPage = () => {
         >
           <AgreeModalInner
             setMarketingAllowed={(value: boolean) => setMarketAllowed(value)}
+            onPolicyPreview={(policy: TermType) => {
+              getPolicy(policy);
+            }}
             onNext={setIsAgreeModal}
+            accountType="USER"
           />
         </BottomSheetLayout>
+      )}
+      {isPolicyPreview === true && (
+        <PolicyViewer
+          content={policy}
+          onBack={() => setIsPolicyPreview(false)}
+        />
+      )}
+      {isLoading && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-white bg-opacity-50 overflow-hidden"
+          style={{ touchAction: 'none' }}
+          onClick={(e) => e.preventDefault()}
+        >
+          <LoadingItem />
+        </div>
       )}
     </div>
   );

--- a/src/pages/Information/InformationPage.tsx
+++ b/src/pages/Information/InformationPage.tsx
@@ -10,6 +10,7 @@ import { useSignUp } from '@/hooks/api/useAuth';
 import {
   initialUserInfoRequestBody,
   Language,
+  TermType,
   UserInfoRequestBody,
 } from '@/types/api/users';
 import { getTemporaryToken } from '@/utils/auth';
@@ -35,13 +36,28 @@ const InformationPage = () => {
   };
   // 최종 완료 시 호출, 서버 api 호출 및 완료 modal 표시
   const handleSubmit = (language: Language) => {
+    const termTypes = [
+      TermType.PERSONAL_SERVICE_TERMS,
+      TermType.LOCATION_BASED_TERMS,
+      TermType.PRIVACY_POLICY,
+    ];
+    console.log({
+      ...userInfo,
+      marketing_allowed: marketingAllowed,
+      notification_allowed: false,
+      temporary_token: String(getTemporaryToken()),
+      language: language,
+      term_types: termTypes,
+    })
     mutate({
       ...userInfo,
       marketing_allowed: marketingAllowed,
       notification_allowed: false,
       temporary_token: String(getTemporaryToken()),
       language: language,
+      term_types: termTypes,
     });
+
   };
   return (
     <div className="m-auto max-w-[500px] relative h-screen flex flex-col items-center justify-start border border-black overflow-y-scroll scrollbar-hide">

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -66,3 +66,7 @@ export type ReIssueAuthenticationRequest = {
   id: string;
   email: string;
 };
+
+export type PolicyResponse = {
+  content: string;
+};

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,5 +1,5 @@
 import { UserType } from '@/constants/user';
-import { Address, Language, UserInfo } from '@/types/api/users';
+import { Address, Language, TermType, UserInfo } from '@/types/api/users';
 
 export type SignInRequest = FormData;
 
@@ -31,6 +31,7 @@ export type SignUpRequest = {
   marketing_allowed: boolean;
   notification_allowed: boolean;
   language: Language;
+  term_types: TermType[];
 };
 /*
 export type OwnerSignUpRequest = {

--- a/src/types/api/users.ts
+++ b/src/types/api/users.ts
@@ -34,9 +34,15 @@ export const enum Language {
   ENGLISH = 'ENGLISH',
 }
 
+export const enum TermType {
+  PERSONAL_SERVICE_TERMS = 'personal-service-terms',
+  ENTERPRISE_SERVICE_TERMS = 'enterprise-service-terms',
+  LOCATION_BASED_TERMS = 'location-based-terms',
+  PRIVACY_POLICY = 'privacy-policy',
+}
+
 // Type for user info with nullable fields
 export type UserInfo = {
-  marketing_allow: boolean | null;
   first_name: string | null;
   last_name: string | null;
   gender: string | null;
@@ -68,7 +74,6 @@ export type UserInfoRequestBody = {
 
 // Initial state for UserInfo
 export const initialUserInfo: UserInfo = {
-  marketing_allow: null,
   first_name: '',
   last_name: '',
   gender: 'MALE',

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -177,10 +177,8 @@ export const validateLaborContractEmployerInformation = (
 // number만 가능한 필드에서 NaN 입력으로 input이 멈추지 않게 값 검증
 export const parseStringToSafeNumber = (value: string): number => {
   const numberValue = Number(value);
-  const minimumWage2025 = 10030;
 
   if (isNaN(numberValue)) return 0;
-  if (!isNaN(numberValue) && numberValue < minimumWage2025) return 0;
   else return numberValue;
 };
 


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

#99

## Work Description ✏️

- 약관 조회 추가로 인한 기능 추가 및 변경
  - 수정된 회원가입 명세 적용, 약관 동의 항목 서버로 전달
  - 약관별 상세 조회 뷰 작성(유학생/고용주 분리)
  - 약관 로드 시 로딩 처리

- 시급 입력이 불가하던 오류 수정
<img src="https://github.com/user-attachments/assets/b1556e63-6332-43eb-8f9c-5d4aebf55063" width="300" />

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] 추후 나머지 약관들 작성되어 추가되면 뷰 체크 필요

## To Reviewers 📢

- 현재 개인정보 관련 약관밖에 없는 상태로, 나머지 약관은 조회 시 "temp" 값이 반환됩니다.
