### PR TITLE
🐛 fix: 별도 문서 없는 마케팅 이용동의 약관 확인 버튼 제거 #99

### DIFF
--- a/src/components/Employer/Signup/AgreeModalInner.tsx
+++ b/src/components/Employer/Signup/AgreeModalInner.tsx
@@ -147,7 +147,6 @@ const AgreeModalInner = ({
               <div className="w-full flex items-center">
                 (선택) 마케팅 이용동의
               </div>
-              <ArrowIcon />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Related issue 🛠

#99 

## Work Description ✏️

- 별도 문서 없는 마케팅 이용동의 약관 확인 버튼 제거
<img width="300" alt="스크린샷 2025-01-21 오전 1 05 06" src="https://github.com/user-attachments/assets/c06b020f-7d0b-4391-8354-1efe31ce4f04" />

## Uncompleted Tasks 😅

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
