### PR TITLE
[Fix/159] 토큰 재발급, coordinator 찾기에서 null 처리, 웹뷰 뒤로가기 문제 해결하기

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   getAccessToken,
   getRefreshToken,
@@ -62,7 +63,10 @@ function setInterceptors(instance: AxiosInstance, type: string) {
     (response) => response,
     async (error) => {
       if (error.response && error.response.status === 401) {
-        if (error.response.data.error.code === 40101) {
+        if (
+          error.response.data.error.code === 40101 ||
+          error.response.data.error.code === 40102
+        ) {
           console.log('401');
 
           const refreshToken = getRefreshToken();

--- a/src/components/ApplicationDetail/ContactCoordinatorModal.tsx
+++ b/src/components/ApplicationDetail/ContactCoordinatorModal.tsx
@@ -55,21 +55,24 @@ const ContactCoordinatorModal = ({
             <p className="pb-[0.75rem] px-[0.5rem] caption-1 text-[##656565]">
               {coordinatorData?.address?.address_detail}
             </p>
-            <Map
-              center={{
-                lat: coordinatorData.address.latitude,
-                lng: coordinatorData.address.longitude,
-              }}
-              style={{ width: '100%', height: '99px' }}
-              className="rounded-xl"
-            >
-              <MapMarker
-                position={{
-                  lat: coordinatorData.address.latitude,
-                  lng: coordinatorData.address.longitude,
-                }}
-              ></MapMarker>
-            </Map>
+            {coordinatorData?.address?.latitude &&
+              coordinatorData?.address?.longitude && (
+                <Map
+                  center={{
+                    lat: coordinatorData.address.latitude,
+                    lng: coordinatorData.address.longitude,
+                  }}
+                  style={{ width: '100%', height: '99px' }}
+                  className="rounded-xl"
+                >
+                  <MapMarker
+                    position={{
+                      lat: coordinatorData.address.latitude,
+                      lng: coordinatorData.address.longitude,
+                    }}
+                  ></MapMarker>
+                </Map>
+              )}
           </div>
         </div>
         <div className="flex items-center justify-center">

--- a/src/components/Common/ScrollToTop.tsx
+++ b/src/components/Common/ScrollToTop.tsx
@@ -5,6 +5,11 @@ const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
+    // 브라우저 기본 스크롤 복원을 비활성화
+    if (window.history.scrollRestoration === 'auto') {
+      window.history.scrollRestoration = 'manual';
+    }
+
     window.scrollTo(0, 0);
   }, [pathname]);
 


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- #159

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- expo에서 웹뷰를 띄웠을 때 뒤로가기 시에 스크롤 문제 해결하기 위해 모두 최상단으로 스크롤 처리
- 서류 작성 후에 coordinator 찾기에서 데이터 Null일 때 예외처리 -> 이거 추후에 디자인 수정되면 반영해야 함!
- 토큰 재발급 경우는 40101뿐만 아니라 40102도 추가하기

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Task1

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

이게 브라우저로 확인하면 뒤로가기해도 이전 스크롤 위치가 복원되는데 expo로 띄운 웹에서 웹뷰로 확인하면 뒤로가기했을 때 종종 스크롤이 혼자 최상단으로 올라가면서 흰 화면이 나오는데ㅠㅠ 일단은 모든 경우에 최상단으로 스크롤 처리하니깐 괜찮더라구요! 나중에 더 정확한 이유를 찾으면 수정해야할 것 같습니다..
