### PR TITLE
Fix/166 프로필수정주소추가

### DIFF
--- a/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
+++ b/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
@@ -2,7 +2,6 @@ import Dropdown, { DropdownModal } from '@/components/Common/Dropdown';
 import Input from '@/components/Common/Input';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 import { phone } from '@/constants/information';
-import { useGetGeoInfo } from '@/hooks/api/useKaKaoMap';
 import { InputType } from '@/types/common/input';
 import { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
@@ -54,6 +53,15 @@ const EmployerEditInputSection = ({
     middle: '',
     end: '',
   });
+
+  useEffect(() => {
+    if (newEmployData.address.latitude && newEmployData.address.longitude) {
+      setCurrentGeoInfo({
+        lat: newEmployData.address.latitude,
+        lon: newEmployData.address.longitude,
+      });
+    }
+  }, [newEmployData.address.latitude, newEmployData.address.longitude]);
 
   useEffect(() => {
     if (initialPhonNum) {

--- a/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
+++ b/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
@@ -20,6 +20,7 @@ import { useAddressSearch } from '@/hooks/api/useAddressSearch';
 type EmployerEditInputSectionProps = {
   newEmployData: EmployerProfileRequestBody;
   setNewEmployData: (newData: EmployerProfileRequestBody) => void;
+  logo?: string;
   setLogoFile: (file: File | undefined) => void;
   initialPhonNum: string;
 };
@@ -27,12 +28,14 @@ type EmployerEditInputSectionProps = {
 const enum LogoType {
   DEFAULT = 'default',
   NONE = 'none',
+  EXISTING = 'existing',
   SELECTED = 'selected',
 }
 
 const EmployerEditInputSection = ({
   newEmployData,
   setNewEmployData,
+  logo,
   setLogoFile,
   initialPhonNum,
 }: EmployerEditInputSectionProps) => {
@@ -63,20 +66,13 @@ const EmployerEditInputSection = ({
     }
   }, [initialPhonNum]);
 
-  const [logoStatus, setLogoStatus] = useState<LogoType>(LogoType.NONE);
+  const [logoStatus, setLogoStatus] = useState<LogoType>(
+    logo ? LogoType.EXISTING : LogoType.NONE,
+  );
   const [selectedImage, setSelectedImage] = useState<string>();
-  // 현재 좌표 기준 주소 획득
-  const { data, isSuccess } = useGetGeoInfo(setCurrentGeoInfo);
-  // 첫 로딩 시 현재 사용자의 위치 파악 해 지도에 표기
   useEffect(() => {
-    setNewEmployData({
-      ...newEmployData,
-      address: {
-        ...newEmployData.address,
-        address_name: String(data?.address.address_name),
-      },
-    });
-  }, [isSuccess]);
+    setAddressInput(String(newEmployData.address.address_name));
+  }, [newEmployData.address.address_name]);
 
   useEffect(() => {
     setNewEmployData({
@@ -305,6 +301,19 @@ const EmployerEditInputSection = ({
                       <div className="relative w-full h-full group">
                         <img
                           src={selectedImage}
+                          alt="Selected logo"
+                          className="w-full h-full object-cover rounded-lg"
+                        />
+                        {/* Hover overlay */}
+                        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-opacity rounded-lg flex items-center justify-center">
+                          <FileAddIcon className="text-white opacity-0 group-hover:opacity-100 transition-opacity" />
+                        </div>
+                      </div>
+                    )}
+                    {logoStatus === LogoType.EXISTING && logo && (
+                      <div className="relative w-full h-full group">
+                        <img
+                          src={logo}
                           alt="Selected logo"
                           className="w-full h-full object-cover rounded-lg"
                         />

--- a/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
+++ b/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
@@ -3,7 +3,6 @@ import Input from '@/components/Common/Input';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 import { phone } from '@/constants/information';
 import { useGetGeoInfo } from '@/hooks/api/useKaKaoMap';
-import { AddressType } from '@/types/api/map';
 import { InputType } from '@/types/common/input';
 import { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
@@ -197,12 +196,7 @@ const EmployerEditInputSection = ({
                 <DropdownModal
                   value={newEmployData.address.address_name}
                   options={Array.from(
-                    addressSearchResult.filter(
-                      (address) =>
-                        address.address_type !==
-                        (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                    ),
-                    (address) => address.address_name,
+                    addressSearchResult.map((address) => address.address_name),
                   )}
                   onSelect={handleAddressSelection}
                 />

--- a/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
+++ b/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
@@ -74,9 +74,7 @@ const EmployerEditInputSection = ({
     }
   }, [initialPhonNum]);
 
-  const [logoStatus, setLogoStatus] = useState<LogoType>(
-    logo ? LogoType.EXISTING : LogoType.NONE,
-  );
+  const [logoStatus, setLogoStatus] = useState<LogoType>(LogoType.EXISTING);
   const [selectedImage, setSelectedImage] = useState<string>();
   useEffect(() => {
     setAddressInput(String(newEmployData.address.address_name));

--- a/src/components/Employer/PostCreate/Step2.tsx
+++ b/src/components/Employer/PostCreate/Step2.tsx
@@ -3,7 +3,6 @@ import Button from '@/components/Common/Button';
 import Dropdown, { DropdownModal } from '@/components/Common/Dropdown';
 import Input from '@/components/Common/Input';
 import InputLayout from '@/components/WorkExperience/InputLayout';
-import { AddressType } from '@/types/api/map';
 import { InputType } from '@/types/common/input';
 import { JobPostingForm } from '@/types/postCreate/postCreate';
 import { useEffect, useState } from 'react';
@@ -82,12 +81,7 @@ const Step2 = ({
               <DropdownModal
                 value={newPostInfo.body.address.address_name}
                 options={Array.from(
-                  addressSearchResult.filter(
-                    (address) =>
-                      address.address_type !==
-                      (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                  ),
-                  (address) => address.address_name,
+                  addressSearchResult.map((address) => address.address_name),
                 )}
                 onSelect={handleAddressSelection}
               />

--- a/src/components/Employer/Signup/InformationInputSection.tsx
+++ b/src/components/Employer/Signup/InformationInputSection.tsx
@@ -4,7 +4,6 @@ import InputLayout from '@/components/WorkExperience/InputLayout';
 import { phone } from '@/constants/information';
 import { useGetGeoInfo } from '@/hooks/api/useKaKaoMap';
 import { EmployerRegistrationRequestBody } from '@/types/api/employ';
-import { AddressType } from '@/types/api/map';
 import { InputType } from '@/types/common/input';
 import { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
@@ -184,12 +183,7 @@ const InformationInputSection = ({
                 <DropdownModal
                   value={newEmployData.address.address_name}
                   options={Array.from(
-                    addressSearchResult.filter(
-                      (address) =>
-                        address.address_type !==
-                        (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                    ),
-                    (address) => address.address_name,
+                    addressSearchResult.map((address) => address.address_name),
                   )}
                   onSelect={handleAddressSelection}
                 />
@@ -199,7 +193,7 @@ const InformationInputSection = ({
             <div className="w-full rounded-xl">
               <Map
                 center={{ lat: currentGeoInfo.lat, lng: currentGeoInfo.lon }}
-                style={{ width: '100%', height: '200px' }}
+                style={{ width: '100%', height: '200px', zIndex: -100 }}
                 className="rounded-xl"
               >
                 <MapMarker

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -70,6 +70,7 @@ const EmployerLaborContractForm = ({
     addressInput, // 주소 검색용 input 저장하는 state
     addressSearchResult, // 주소 검색 결과를 저장하는 array
     currentGeoInfo, // 지도에 표시할 핀에 사용되는 위/경도 좌표
+    setCurrentGeoInfo,
     handleAddressSearch, // 검색할 주소 입력 시 실시간 검색
     handleAddressSelect, // 검색 결과 중 원하는 주소를 선택할 시 state에 입력
     setAddressInput,
@@ -93,6 +94,10 @@ const EmployerLaborContractForm = ({
         end: parsePhoneNumber(document?.employee_information.phone_number).end,
       });
       setAddressInput(document.employer_information.address.address_name ?? '');
+      setCurrentGeoInfo({
+        lat: document.employer_information.address.latitude as number,
+        lon: document.employer_information.address.longitude as number,
+      });
     }
   }, [document, isEdit]);
 

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -14,7 +14,6 @@ import {
   PaymentMethod,
   WorkDayTimeWithRest,
 } from '@/types/api/document';
-import { AddressType } from '@/types/api/map';
 import { InputType } from '@/types/common/input';
 import { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
@@ -296,12 +295,7 @@ const EmployerLaborContractForm = ({
                 <DropdownModal
                   value={newDocumentData.address.address_name}
                   options={Array.from(
-                    addressSearchResult.filter(
-                      (address) =>
-                        address.address_type !==
-                        (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                    ),
-                    (address) => address.address_name,
+                    addressSearchResult.map((address) => address.address_name),
                   )}
                   onSelect={handleAddressSelection}
                 />

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -95,8 +95,8 @@ const EmployerLaborContractForm = ({
       });
       setAddressInput(document.employer_information.address.address_name ?? '');
       setCurrentGeoInfo({
-        lat: document.employer_information.address.latitude as number,
-        lon: document.employer_information.address.longitude as number,
+        lat: document.employer_information.address.latitude ?? 0,
+        lon: document.employer_information.address.longitude ?? 0,
       });
     }
   }, [document, isEdit]);

--- a/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
@@ -99,8 +99,8 @@ const EmployerPartTimePermitForm = ({
       });
       setAddressInput(document.employer_information.address.address_name ?? '');
       setCurrentGeoInfo({
-        lat: document.employer_information.address.latitude as number,
-        lon: document.employer_information.address.longitude as number,
+        lat: document.employer_information.address.latitude ?? 0,
+        lon: document.employer_information.address.longitude ?? 0,
       });
     }
   }, [document, isEdit]);

--- a/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
@@ -11,7 +11,6 @@ import {
   PartTimePermitData,
   WorkPeriod,
 } from '@/types/api/document';
-import { AddressType } from '@/types/api/map';
 import { InputType } from '@/types/common/input';
 import { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
@@ -213,12 +212,7 @@ const EmployerPartTimePermitForm = ({
                 <DropdownModal
                   value={newDocumentData.address.address_name}
                   options={Array.from(
-                    addressSearchResult.filter(
-                      (address) =>
-                        address.address_type !==
-                        (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                    ),
-                    (address) => address.address_name,
+                    addressSearchResult.map((address) => address.address_name),
                   )}
                   onSelect={handleAddressSelection}
                 />

--- a/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
@@ -63,6 +63,7 @@ const EmployerPartTimePermitForm = ({
     addressInput, // 주소 검색용 input 저장하는 state
     addressSearchResult, // 주소 검색 결과를 저장하는 array
     currentGeoInfo, // 지도에 표시할 핀에 사용되는 위/경도 좌표
+    setCurrentGeoInfo,
     handleAddressSearch, // 검색할 주소 입력 시 실시간 검색
     handleAddressSelect, // 검색 결과 중 원하는 주소를 선택할 시 state에 입력
     setAddressInput,
@@ -97,6 +98,10 @@ const EmployerPartTimePermitForm = ({
         end: parsePhoneNumber(document?.employee_information.phone_number).end,
       });
       setAddressInput(document.employer_information.address.address_name ?? '');
+      setCurrentGeoInfo({
+        lat: document.employer_information.address.latitude as number,
+        lon: document.employer_information.address.longitude as number,
+      });
     }
   }, [document, isEdit]);
 

--- a/src/components/Information/AddressStep.tsx
+++ b/src/components/Information/AddressStep.tsx
@@ -10,7 +10,6 @@ import { useEffect, useState } from 'react';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import { useGetGeoInfo} from '@/hooks/api/useKaKaoMap';
 import { DropdownModal } from '@/components/Common/Dropdown';
-import { AddressType } from '@/types/api/map';
 import Button from '@/components/Common/Button';
 import { useAddressSearch } from '@/hooks/api/useAddressSearch';
 
@@ -73,12 +72,7 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
                 newAddress.address_name === null ? '' : newAddress.address_name
               }
               options={Array.from(
-                addressSearchResult.filter(
-                  (address) =>
-                    address.address_type !==
-                    (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                ),
-                (address) => address.address_name,
+                addressSearchResult.map((address) => address.address_name),
               )}
               onSelect={handleAddressSelection}
             />

--- a/src/components/Information/AddressStep.tsx
+++ b/src/components/Information/AddressStep.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/types/api/users';
 import { useEffect, useState } from 'react';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
-import { useGetGeoInfo} from '@/hooks/api/useKaKaoMap';
+import { useGetGeoInfo } from '@/hooks/api/useKaKaoMap';
 import { DropdownModal } from '@/components/Common/Dropdown';
 import Button from '@/components/Common/Button';
 import { useAddressSearch } from '@/hooks/api/useAddressSearch';
@@ -46,7 +46,7 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
   const handleAddressSelection = (selectedAddressName: string) => {
     const result = handleAddressSelect(selectedAddressName);
     if (!result) return;
-    setNewAddress({...newAddress, ...result.addressData});
+    setNewAddress({ ...newAddress, ...result.addressData });
     setAddressInput(result.selectedAddressName);
   };
 
@@ -99,6 +99,8 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
             placeholder="ex) 101-dong"
             value={newAddress.address_detail}
             onChange={(value) =>
+              newAddress.address_detail &&
+              newAddress.address_detail.trim().length < 100 &&
               setNewAddress({ ...newAddress, address_detail: value })
             }
             canDelete={false}

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -23,7 +23,11 @@ import {
   usePostIntegratedApplicants,
   usePutIntegratedApplicants,
 } from '@/hooks/api/useDocument';
-import { formatCompanyRegistrationNumber, formatPhoneNumber, parsePhoneNumber } from '@/utils/information';
+import {
+  formatCompanyRegistrationNumber,
+  formatPhoneNumber,
+  parsePhoneNumber,
+} from '@/utils/information';
 import { useCurrentPostIdEmployeeStore } from '@/store/url';
 import LoadingItem from '../Common/LoadingItem';
 import { useAddressSearch } from '@/hooks/api/useAddressSearch';
@@ -309,6 +313,8 @@ const IntegratedApplicationWriteForm = ({
                 placeholder="ex) 101-dong"
                 value={newDocumentData.address.address_detail}
                 onChange={(value) =>
+                  newDocumentData.address.address_detail &&
+                  newDocumentData.address.address_detail.trim().length < 100 &&
                   setNewDocumentData({
                     ...newDocumentData,
                     address: {

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -122,8 +122,8 @@ const IntegratedApplicationWriteForm = ({
       });
       setAddressInput(newDocumentData.address.address_name as string);
       setCurrentGeoInfo({
-        lat: document.address.latitude as number,
-        lon: document.address.longitude as number,
+        lat: document.address.latitude ?? 0,
+        lon: document.address.longitude ?? 0,
       });
     }
   }, [document, isEdit]);

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -72,6 +72,7 @@ const IntegratedApplicationWriteForm = ({
     addressInput, // 주소 검색용 input 저장하는 state
     addressSearchResult, // 주소 검색 결과를 저장하는 array
     currentGeoInfo, // 지도에 표시할 핀에 사용되는 위/경도 좌표
+    setCurrentGeoInfo,
     handleAddressSearch, // 검색할 주소 입력 시 실시간 검색
     handleAddressSelect, // 검색 결과 중 원하는 주소를 선택할 시 state에 입력
     setAddressInput,
@@ -120,6 +121,10 @@ const IntegratedApplicationWriteForm = ({
         end: parsePhoneNumber(newDocumentData.school_phone_number).end,
       });
       setAddressInput(newDocumentData.address.address_name as string);
+      setCurrentGeoInfo({
+        lat: document.address.latitude as number,
+        lon: document.address.longitude as number,
+      });
     }
   }, [document, isEdit]);
   // 데이터 입력 시 실시간으로 유효성 검사

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -1,6 +1,5 @@
 import { initialIntegratedApplication } from '@/constants/documents';
 import { IntegratedApplicationData } from '@/types/api/document';
-import { AddressType } from '@/types/api/map';
 import { useEffect, useState } from 'react';
 import Input from '@/components/Common/Input';
 import { InputType } from '@/types/common/input';
@@ -283,12 +282,7 @@ const IntegratedApplicationWriteForm = ({
                 <DropdownModal
                   value={newDocumentData.address.address_name}
                   options={Array.from(
-                    addressSearchResult.filter(
-                      (address) =>
-                        address.address_type !==
-                        (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                    ),
-                    (address) => address.address_name,
+                    addressSearchResult.map((address) => address.address_name),
                   )}
                   onSelect={handleAddressSelection}
                 />

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -12,7 +12,6 @@ import Dropdown, { DropdownModal } from '@/components/Common/Dropdown';
 import { phone } from '@/constants/information';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import { useGetGeoInfo } from '@/hooks/api/useKaKaoMap';
-import { AddressType } from '@/types/api/map';
 import { isNotEmpty } from '@/utils/document';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
@@ -217,12 +216,7 @@ const LaborContractWriteForm = ({
                 <DropdownModal
                   value={newDocumentData.address.address_name}
                   options={Array.from(
-                    addressSearchResult.filter(
-                      (address) =>
-                        address.address_type !==
-                        (AddressType.REGION_ADDR || AddressType.ROAD_ADDR),
-                    ),
-                    (address) => address.address_name,
+                    addressSearchResult.map((address) => address.address_name),
                   )}
                   onSelect={handleAddressSelection}
                 />

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -251,6 +251,8 @@ const LaborContractWriteForm = ({
                 placeholder="ex) 101-dong"
                 value={newDocumentData.address.address_detail}
                 onChange={(value) =>
+                  newDocumentData.address.address_detail &&
+                  newDocumentData.address.address_detail.trim().length < 100 &&
                   setNewDocumentData({
                     ...newDocumentData,
                     address: {

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -93,8 +93,8 @@ const LaborContractWriteForm = ({
       });
       setAddressInput(newDocumentData.address.address_name as string);
       setCurrentGeoInfo({
-        lat: newDocumentData.address.latitude as number,
-        lon: newDocumentData.address.longitude as number,
+        lat: newDocumentData.address.latitude ?? 0,
+        lon: newDocumentData.address.longitude ?? 0,
       });
     }
   }, [document, isEdit]);

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -92,6 +92,10 @@ const LaborContractWriteForm = ({
         end: parsePhoneNumber(newDocumentData.phone_number).end,
       });
       setAddressInput(newDocumentData.address.address_name as string);
+      setCurrentGeoInfo({
+        lat: newDocumentData.address.latitude as number,
+        lon: newDocumentData.address.longitude as number,
+      });
     }
   }, [document, isEdit]);
 

--- a/src/hooks/api/useAddressSearch.ts
+++ b/src/hooks/api/useAddressSearch.ts
@@ -1,6 +1,6 @@
+import { Address } from '@/types/api/users';
 import { useSearchAddress } from '@/hooks/api/useKaKaoMap';
 import { Document, AddressType, GeoPosition } from '@/types/api/map';
-import { Address } from '@/types/postCreate/postCreate';
 import { pick } from '@/utils/map';
 import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 

--- a/src/hooks/api/useAddressSearch.ts
+++ b/src/hooks/api/useAddressSearch.ts
@@ -65,8 +65,7 @@ export const useAddressSearch = (
 
     if (!selectedAddress) return;
 
-    const isRoadAddr = selectedAddress.address_type === AddressType.ROAD;
-    const addressData = isRoadAddr
+    const isRoadAddr = [AddressType.ROAD_ADDR, AddressType.ROAD].includes(selectedAddress.address_type);    const addressData = isRoadAddr
       ? selectedAddress.road_address
       : selectedAddress.address;
 

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -15,6 +15,7 @@ import {
   changeValidData,
   transformToProfileRequest,
   validateChanges,
+  validateFieldValues,
 } from '@/utils/editProfileData';
 import { useEffect, useState } from 'react';
 import { country, phone, visa } from '@/constants/information';
@@ -117,7 +118,11 @@ const EditProfilePage = () => {
 
   // 수정 여부를 확인(프로필 사진만 변경했을 경우 포함)
   useEffect(() => {
-    if (originalData && validateChanges(originalData, userData, phoneNum)) {
+    if (
+      originalData &&
+      validateChanges(originalData, userData, phoneNum) &&
+      validateFieldValues(userData, phoneNum)
+    ) {
       setIsChanged(true);
     } else {
       setIsChanged(false);
@@ -256,8 +261,8 @@ const EditProfilePage = () => {
                     value={userData.address.address_name}
                     options={Array.from(
                       addressSearchResult.map(
-                        (address) => address.address_name
-                      )
+                        (address) => address.address_name,
+                      ),
                     )}
                     onSelect={handleAddressSelection}
                   />
@@ -284,6 +289,8 @@ const EditProfilePage = () => {
                   placeholder="ex) 101dong"
                   value={userData.address.address_detail}
                   onChange={(value) =>
+                    userData.address.address_detail &&
+                    userData.address.address_detail.trim().length < 100 &&
                     setUserData({
                       ...userData,
                       address: {

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -111,8 +111,8 @@ const EditProfilePage = () => {
       setUserData(initailData);
       setAddressInput(userProfile.data.address.address_name ?? '');
       setCurrentGeoInfo({
-        lat: userProfile.data.address.latitude as number,
-        lon: userProfile.data.address.longitude as number,
+        lat: userProfile.data.address.latitude ?? 0,
+        lon: userProfile.data.address.longitude ?? 0,
       });
     }
   }, [userProfile]);

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -45,6 +45,7 @@ const EditProfilePage = () => {
     addressInput, // 주소 검색용 input 저장하는 state
     addressSearchResult, // 주소 검색 결과를 저장하는 array
     currentGeoInfo, // 지도에 표시할 핀에 사용되는 위/경도 좌표
+    setCurrentGeoInfo,
     handleAddressSearch, // 검색할 주소 입력 시 실시간 검색
     handleAddressSelect, // 검색 결과 중 원하는 주소를 선택할 시 state에 입력
     setAddressInput,
@@ -109,6 +110,10 @@ const EditProfilePage = () => {
       setOriginalData(initailData);
       setUserData(initailData);
       setAddressInput(userProfile.data.address.address_name ?? '');
+      setCurrentGeoInfo({
+        lat: userProfile.data.address.latitude as number,
+        lon: userProfile.data.address.longitude as number,
+      });
     }
   }, [userProfile]);
 
@@ -247,7 +252,7 @@ const EditProfilePage = () => {
             </div>
             <div className="w-full flex flex-col gap-[1.125rem]">
               {/* 주소 검색 입력 input */}
-              <InputLayout title="Address" isEssential>
+              <InputLayout title="Address" isEssential={false}>
                 <Input
                   inputType={InputType.SEARCH}
                   placeholder="Search Your Address"

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -269,7 +269,7 @@ const EditProfilePage = () => {
                 )}
               </InputLayout>
               {/* 검색한 위치를 보여주는 지도 */}
-              <div className="w-full rounded-xl">
+              <div className="w-full rounded-xl z-0">
                 <Map
                   center={{ lat: currentGeoInfo.lat, lng: currentGeoInfo.lon }}
                   style={{ width: '100%', height: '200px' }}

--- a/src/pages/Employer/EditProfile/EmployerEditProfilePage.tsx
+++ b/src/pages/Employer/EditProfile/EmployerEditProfilePage.tsx
@@ -75,6 +75,7 @@ const EmployerEditProfilePage = () => {
       />
       <EmployerEditInputSection
         newEmployData={newEmployData}
+        logo={data?.data.logo_img_url}
         setNewEmployData={setNewEmployData}
         setLogoFile={(file: File | undefined) => setLogoFile(file)}
         initialPhonNum={newEmployData.owner_info.phone_number}

--- a/src/types/api/profile.ts
+++ b/src/types/api/profile.ts
@@ -52,6 +52,7 @@ export type UserProfileDetailResponse = {
   nationality: string;
   visa: string;
   phone_number: string;
+  address: Address;
 };
 
 export type UserEditProfileRequest = {
@@ -68,6 +69,7 @@ export type UserEditRequestBody = {
   visa: string; // Enum(D_2_1, D_2_2, D_2_3, D_2_4, D_2_6, D_2_7, D_2_8, D_4_1, D_4_7, F_2)
   phone_number: string;
   is_profile_img_changed: boolean;
+  address: Address;
 };
 
 export const InitialUserProfileDetail: UserEditRequestBody = {
@@ -79,6 +81,16 @@ export const InitialUserProfileDetail: UserEditRequestBody = {
   visa: '', // Enum(D_2_1, D_2_2, D_2_3, D_2_4, D_2_6, D_2_7, D_2_8, D_4_1, D_4_7, F_2)
   phone_number: '',
   is_profile_img_changed: false,
+  address: {
+    address_name: '',
+    region_1depth_name: '',
+    region_2depth_name: '',
+    region_3depth_name: '',
+    region_4depth_name: '',
+    address_detail: '',
+    longitude: 0,
+    latitude: 0,
+  },
 };
 
 // 고용주 프로필

--- a/src/types/postCreate/postCreate.ts
+++ b/src/types/postCreate/postCreate.ts
@@ -61,16 +61,16 @@ export type Address = {
   region_1depth_name: string;
   region_2depth_name: string;
   region_3depth_name: string;
-  region_4depth_name?: string;
+  region_4depth_name: string | null;
   address_detail: string;
   longitude: number;
   latitude: number;
 };
 
 export type Image = {
-  id: number,
+  id: number;
   img_url: string;
-}
+};
 
 export type JobPostingForm = {
   images: (File | Image)[];

--- a/src/utils/editProfileData.ts
+++ b/src/utils/editProfileData.ts
@@ -5,6 +5,7 @@ import {
   UserEditRequestBody,
   UserProfileDetailResponse,
 } from '@/types/api/profile';
+import { isValidPhoneNumber } from './information';
 
 // GET 데이터를 PATCH 요청 데이터로 변환
 export const changeValidData = (
@@ -91,5 +92,38 @@ export const validateChanges = (
       );
     }
     return value !== originalData[typedKey];
+  });
+};
+
+export const validateFieldValues = (
+  userData: UserEditRequestBody,
+  phoneNum: { start: string; middle: string; end: string },
+) => {
+  return Object.entries(userData).every(([key, value]) => {
+    const typedKey = key as keyof UserEditRequestBody;
+    const nameRegex = /^[a-zA-Z가-힣\s]+$/;
+    switch (typedKey) {
+      case 'first_name':
+      case 'last_name':
+        // 50자 제한, 특수문자 사용 불가, 숫자 사용 불가
+        return (
+          String(value).trim().length < 50 && nameRegex.test(String(value))
+        );
+      case 'birth':
+        // 생일이 현재 날짜보다 이전인지 확인
+        return Date.parse(value as string) < Date.now();
+      case 'phone_number':
+        return isValidPhoneNumber(phoneNum);
+      case 'address':
+        // 주소 필드는 address_name이 존재하고, 길이가 0보다 큰지 확인
+        return (
+          typeof value !== 'string' &&
+          typeof value !== 'boolean' &&
+          'address_name' in value &&
+          value.address_name !== null &&
+          value.address_name.length > 0
+        );
+    }
+    return true;
   });
 };

--- a/src/utils/editProfileData.ts
+++ b/src/utils/editProfileData.ts
@@ -24,6 +24,7 @@ export const changeValidData = (
     // phone_number 통합
     phone_number: `${phoneNum.start}-${phoneNum.middle}-${phoneNum.end}`,
     is_profile_img_changed: isProfileImgChanged,
+    address: userData.address,
   };
 };
 
@@ -45,6 +46,7 @@ export const transformToProfileRequest = (
     visa: data.visa.replace(/_/g, '-'),
     phone_number: data.phone_number,
     is_profile_img_changed: false,
+    address: data.address,
   };
 };
 

--- a/src/utils/employerProfile.ts
+++ b/src/utils/employerProfile.ts
@@ -7,17 +7,21 @@ const isValidString = (value: string): boolean => {
 export const isValidEmployerProfile = (
   data: EmployerProfileRequestBody,
 ): boolean => {
+  const nameRegex = /^[a-zA-Z가-힣\s]+$/;
+  const companyRegistrationNumPattern = /^\d{3}\/\d{2}\/\d{5}$/;
   const phonePattern = /.*-\d{4}-\d{4}$/;
   // owner_info의 모든 필드 체크
   const { owner_info } = data;
   if (
     !isValidString(owner_info.company_name) ||
     !isValidString(owner_info.owner_name) ||
+    !nameRegex.test(owner_info.owner_name) ||
     !isValidString(owner_info.company_registration_number) ||
+    !companyRegistrationNumPattern.test(owner_info.company_registration_number) ||
     !phonePattern.test(owner_info.phone_number)
-  ) {
+) {
     return false;
-  }
+}
 
   // address의 필수 필드 체크
   const { address } = data;


### PR DESCRIPTION
## Related issue 🛠

#166 

## Work Description ✏️

- 유학생 프로필 수정 시 주소 수정이 가능하도록 추가
- 기존에는 지역명, 도로명 주소만 검색 및 선택이 가능했으나 지번 주소 까지 선택 가능하도록 주소 검색 컴포넌트 변경
  - 지번, 도로명 주소, 지역명, 도로명 으로도 검색 및 선택 가능하도록 수정
  - 도로명 주소와 지번 주소가 모두 존재하는 주소의 경우 도로명 주소로 검색, 선택했음에도 지번 주소로 입력되던 현상 수정

- 지도 컴포넌트가 저장 버튼 위로 올라오던 현상 수정


<img width="300" src="https://github.com/user-attachments/assets/1bcf8600-21b0-4e03-b45a-cfb0d07d45d6" />

- 프로필 수정값 입력 시 유효성 검사 적용
  - 이름, 생년월일, 주소, 전화번호

<img width="300" src="https://github.com/user-attachments/assets/f1b55c7b-ff52-4753-81ff-312bd19dd0bd" />

- 고용주 회사/점포 정보 수정 유효성 검사 적용

- 고용주 회사/점포 정보 수정 시 로고, 위치에 따른 지도 자동 입력 및 표기 ( before vs after )
<img width="300" src="https://github.com/user-attachments/assets/1bcf8600-21b0-4e03-b45a-cfb0d07d45d6" />
<img width="300" src="https://github.com/user-attachments/assets/24078f93-6577-4321-8108-2507fc304b58" />



- 그 외 문서 수정 시 주소에 따른 지도 위치 자동 표기
  - 고용주 근로계약서, 시간제근로허가서, 유학생 근로계약서, 통합신청서, 프로필 수정 시 적용
<img width="300" src="https://github.com/user-attachments/assets/837ce6b1-08c8-49ce-a328-113186106aa9" />

## Uncompleted Tasks 😅

- [x] 프로필 수정 시 유효성 검사 적용
- [x] 현재 도로명 주소와 지번이 둘 다 있는 주소를 선택할 경우 서버로 전송 시 지번 주소가 가능 현상이 있음
- [x] 고용주 회사 정보/프로필 수정도 마찬가지로 유효성 검사가 미적용..
## To Reviewers 📢
