### PR TITLE
[Fix/170] BottomSheet에서 window.innerHeight를 렌더링된 후 사용하도록 수정

### DIFF
--- a/src/components/Common/BottomSheetLayout.tsx
+++ b/src/components/Common/BottomSheetLayout.tsx
@@ -11,7 +11,6 @@ type BottomSheetLayoutProps = {
   isFixedBackground?: boolean;
 };
 
-const VIEW_HEIGHT = window.innerHeight;
 const LAYOUT_MARGIN = 64;
 
 const BottomSheetLayout = ({
@@ -27,6 +26,7 @@ const BottomSheetLayout = ({
   const { setIsOpen, onDragEnd, controls } =
     useBottomSheet(setIsShowBottomSheet);
   const [contentHeight, setContentHeight] = useState<number>(0);
+  const [viewHeight, setViewHeight] = useState<number>(window.innerHeight);
 
   useEffect(() => {
     setIsOpen(isShowBottomsheet);
@@ -37,6 +37,7 @@ const BottomSheetLayout = ({
     if (contentRef.current) {
       const height = contentRef.current.offsetHeight;
       setContentHeight(height);
+      setViewHeight(window.innerHeight);
     }
   }, [contentRef]);
 
@@ -76,7 +77,7 @@ const BottomSheetLayout = ({
         dragElastic={0.2}
         className={`fixed left-0 bottom-0 w-full h-[90vh] p-[1.5rem] pb-[2.5rem] rounded-t-[2.5rem] bg-white shadow-bottomSheetShadow z-30`}
         style={{
-          top: `${VIEW_HEIGHT - contentHeight - LAYOUT_MARGIN}px`,
+          top: `${viewHeight - contentHeight - LAYOUT_MARGIN}px`,
         }}
       >
         {hasHandlebar && (


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #170

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- BottomSheet가 앱에서 설정한 위치보다 더 화면의 위쪽에 나타나는 문제를 해결하기 위해 window.innerHeight을 렌더링된 후 사용하도록 수정했습니다! (웹브라우저에서는 문제가 없었는데 앱으로 실행했을 때 window.innerHeight 값이 0으로 계산되고 있었습니다)


https://github.com/user-attachments/assets/8fa3834a-33ce-4f28-b9ee-aef2b5114b7a



## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
