### PR TITLE
Feature/172 회원가입프로필내선택입력사항적용

### DIFF
--- a/src/components/Common/BottomSheetLayout.tsx
+++ b/src/components/Common/BottomSheetLayout.tsx
@@ -53,7 +53,7 @@ const BottomSheetLayout = ({
   return (
     <>
       {isShowBottomsheet && isFixedBackground && (
-        <div className="fixed w-screen h-screen top-0 bottom-0 left-0 right-0 bg-[rgba(0,0,0,0.3)] z-30"></div>
+        <div className="fixed w-screen h-screen top-0 bottom-0 left-0 right-0 bg-[rgba(0,0,0,0.3)] z-40"></div>
       )}
       <motion.div
         drag="y"
@@ -74,7 +74,7 @@ const BottomSheetLayout = ({
           bottom: contentHeight,
         }} // 상단과 하단 드래그 제한 설정
         dragElastic={0.2}
-        className={`fixed left-0 bottom-0 w-full h-[90vh] p-[1.5rem] pb-[2.5rem] rounded-t-[2.5rem] bg-white shadow-bottomSheetShadow z-30`}
+        className={`fixed left-0 bottom-0 w-full h-[90vh] p-[1.5rem] pb-[2.5rem] rounded-t-[2.5rem] bg-white shadow-bottomSheetShadow z-40`}
         style={{
           top: `${VIEW_HEIGHT - contentHeight - LAYOUT_MARGIN}px`,
         }}

--- a/src/components/Common/Dropdown.tsx
+++ b/src/components/Common/Dropdown.tsx
@@ -71,7 +71,7 @@ const Dropdown = ({
       )}
       {/* 드롭다운 입력 영역 */}
       <div className="w-full flex flex-col gap-2">
-        <div className="w-full relative shadow rounded-lg bg-white border border-[#eae9f6] box-border h-11 flex flex-row items-center justify-center px-4 py-2.5 pl-4 text-left body-2 text-[#656565]">
+        <div className="w-full relative rounded-lg bg-white border border-[#eae9f6] box-border h-11 flex flex-row items-center justify-center px-4 py-2.5 pl-4 text-left body-2 text-[#656565]">
           <div className="flex-1 h-5 flex flex-row items-center justify-between">
             <input
               className="w-full relative leading-5 outline-none bg-white"

--- a/src/components/Common/Header/BaseHeader.tsx
+++ b/src/components/Common/Header/BaseHeader.tsx
@@ -17,10 +17,10 @@ const BaseHeader = ({
   title,
 }: HeaderProps) => {
   return (
-    <section className="w-full h-[3.5rem] px-[0.75rem] py-[0.5rem] flex justify-between items-center bg-white sticky top-0 z-40">
+    <section className="w-full h-[3.75rem] px-[0.75rem] py-[0.75rem] flex justify-between items-center bg-white sticky top-0 z-40 border-b border-solid border-[#ECECEC]">
       {hasBackButton ? (
         <button
-          className="p-[0.5rem] rounded-[0.75rem] border border-solid border-[#ECECEC]"
+          className="p-[0.5rem] border-white"
           onClick={onClickBackButton}
         >
           <BackButtonIcon />

--- a/src/components/Common/Input.tsx
+++ b/src/components/Common/Input.tsx
@@ -33,11 +33,11 @@ type InputProps = {
 const inputStyler = (status: InputStatus) => {
   switch (status) {
     case INPUT_STATUS.DISABLED:
-      return 'shadow-sm border-[#eae9f6] [--input-color:#bdbdbd]';
+      return 'border-[#eae9f6] [--input-color:#bdbdbd]';
     case INPUT_STATUS.TYPING:
-      return 'shadow-sm border-black text-black';
+      return 'border-black text-black';
     case INPUT_STATUS.INVALID:
-      return 'shadow-sm border-[#FF6F61] text-[#FF6F61] [--input-color:#FF6F61]';
+      return 'border-[#FF6F61] text-[#FF6F61] [--input-color:#FF6F61]';
   }
 };
 

--- a/src/components/Information/AddressStep.tsx
+++ b/src/components/Information/AddressStep.tsx
@@ -11,7 +11,7 @@ import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import { DropdownModal } from '@/components/Common/Dropdown';
 import Button from '@/components/Common/Button';
 import { useAddressSearch } from '@/hooks/api/useAddressSearch';
-import InputLayout from '../WorkExperience/InputLayout';
+import InputLayout from '@/components/WorkExperience/InputLayout';
 
 type AddressStepProps = {
   userInfo: UserInfoRequestBody;

--- a/src/components/Information/AddressStep.tsx
+++ b/src/components/Information/AddressStep.tsx
@@ -6,12 +6,12 @@ import {
   initialAddress,
   UserInfoRequestBody,
 } from '@/types/api/users';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
-import { useGetGeoInfo } from '@/hooks/api/useKaKaoMap';
 import { DropdownModal } from '@/components/Common/Dropdown';
 import Button from '@/components/Common/Button';
 import { useAddressSearch } from '@/hooks/api/useAddressSearch';
+import InputLayout from '../WorkExperience/InputLayout';
 
 type AddressStepProps = {
   userInfo: UserInfoRequestBody;
@@ -24,23 +24,10 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
     addressInput, // 주소 검색용 input 저장하는 state
     addressSearchResult, // 주소 검색 결과를 저장하는 array
     currentGeoInfo, // 지도에 표시할 핀에 사용되는 위/경도 좌표
-    setCurrentGeoInfo,
     handleAddressSearch, // 검색할 주소 입력 시 실시간 검색
     handleAddressSelect, // 검색 결과 중 원하는 주소를 선택할 시 state에 입력
     setAddressInput,
   } = useAddressSearch();
-  const { data, isSuccess } = useGetGeoInfo(setCurrentGeoInfo); // 현재 좌표 기준 주소 획득
-
-  // 첫 로딩 시 현재 사용자의 위치 파악 해 지도에 표기
-  useEffect(() => {
-    setNewAddress({
-      ...newAddress,
-      address_name:
-        data?.address.address_name === undefined
-          ? null
-          : data.address.address_name,
-    });
-  }, [isSuccess]);
 
   // 검색된 주소 선택 시 state에 반영
   const handleAddressSelection = (selectedAddressName: string) => {
@@ -54,10 +41,7 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
     <div className="w-full mx-auto">
       <div className="w-full flex flex-col gap-[1.125rem]">
         {/* 주소 검색 입력 input */}
-        <div className="w-full">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Main Address
-          </div>
+        <InputLayout title="Main Address" isEssential={false} isOptional>
           <Input
             inputType={InputType.SEARCH}
             placeholder="Search Your Address"
@@ -77,50 +61,66 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
               onSelect={handleAddressSelection}
             />
           )}
-        </div>
+        </InputLayout>
         {/* 검색한 위치를 보여주는 지도 */}
-        <div className="w-full rounded-xl">
-          <Map
-            center={{ lat: currentGeoInfo.lat, lng: currentGeoInfo.lon }}
-            style={{ width: '100%', height: '200px' }}
-            className="rounded-xl"
-          >
-            <MapMarker
-              position={{ lat: currentGeoInfo.lat, lng: currentGeoInfo.lon }}
-            ></MapMarker>
-          </Map>
-        </div>
-        <div className="w-full">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Detailed Address
-          </div>
-          <Input
-            inputType={InputType.TEXT}
-            placeholder="ex) 101-dong"
-            value={newAddress.address_detail}
-            onChange={(value) =>
-              newAddress.address_detail &&
-              newAddress.address_detail.trim().length < 100 &&
-              setNewAddress({ ...newAddress, address_detail: value })
-            }
-            canDelete={false}
-          />
-        </div>
+        {newAddress.address_name !== '' && (
+          <>
+            <div className="w-full rounded-xl">
+              <Map
+                center={{ lat: currentGeoInfo.lat, lng: currentGeoInfo.lon }}
+                style={{ width: '100%', height: '200px' }}
+                className="rounded-xl"
+              >
+                <MapMarker
+                  position={{
+                    lat: currentGeoInfo.lat,
+                    lng: currentGeoInfo.lon,
+                  }}
+                ></MapMarker>
+              </Map>
+            </div>
+            <InputLayout
+              title="Detailed Address"
+              isEssential={false}
+              isOptional
+            >
+              <Input
+                inputType={InputType.TEXT}
+                placeholder="ex) 101-dong"
+                value={newAddress.address_detail}
+                onChange={(value) => {
+                  if (value.trim().length <= 100) {
+                    // 100자 이하일 때만 업데이트
+                    setNewAddress({ ...newAddress, address_detail: value });
+                  }
+                }}
+                canDelete={false}
+              />
+            </InputLayout>
+          </>
+        )}
       </div>
       {/* 다음 step 이동 버튼 포함한 Bottom Panel */}
       <BottomButtonPanel>
         <Button
           type="large"
           bgColor={
-            newAddress.region_1depth_name === ''
+            newAddress.address_detail &&
+            newAddress.address_detail?.trim().length > 100
               ? 'bg-[#F4F4F9]'
               : 'bg-[#fef387]'
           }
-          fontColor={newAddress.region_1depth_name === '' ? '' : 'text-[#222]'}
+          fontColor={
+            newAddress.address_detail &&
+            newAddress.address_detail?.trim().length > 100
+              ? ''
+              : 'text-[#222]'
+          }
           isBorder={false}
           title="Next"
           onClick={
-            newAddress.region_1depth_name === ''
+            newAddress.address_detail &&
+            newAddress.address_detail?.trim().length > 100
               ? undefined
               : () =>
                   onNext({

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -14,6 +14,7 @@ import { InputType } from '@/types/common/input';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import { formatDateToDash } from '@/utils/editResume';
+import InputLayout from '../WorkExperience/InputLayout';
 const InformationStep = ({
   userInfo,
   onNext,
@@ -55,13 +56,10 @@ const InformationStep = ({
   }, [newUserInfo, phoneNum]);
 
   return (
-    <div className="w-full mx-auto">
-      <div className="w-full flex flex-col gap-[1.125rem]">
+    <div className="w-full mx-auto mb-[7rem]">
+      <div className="w-full flex flex-col gap-[1rem]">
         {/* 이름 작성 */}
-        <div className="w-full">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            First Name
-          </div>
+        <InputLayout title="First Name" isEssential={true}>
           <Input
             inputType={InputType.TEXT}
             placeholder="First Name"
@@ -71,12 +69,9 @@ const InformationStep = ({
             }
             canDelete={false}
           />
-        </div>
+        </InputLayout>
         {/* 성 작성 */}
-        <div className="w-full">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Last Name
-          </div>
+        <InputLayout title="Last Name" isEssential={true}>
           <Input
             inputType={InputType.TEXT}
             placeholder="Last Name"
@@ -86,12 +81,9 @@ const InformationStep = ({
             }
             canDelete={false}
           />
-        </div>
+        </InputLayout>
         {/* 전화번호 선택, dropdown으로 앞 번호를, 중간 번호와 뒷 번호는 각각 input으로 입력 받음 */}
-        <div className="w-full">
-          <div className="w-full flex flex-row items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Telephone No.
-          </div>
+        <InputLayout title="Cell phone No." isEssential={true}>
           <div className="w-full flex flex-row gap-2 justify-between">
             <div className="w-full h-[2.75rem]">
               <Dropdown
@@ -116,11 +108,9 @@ const InformationStep = ({
               canDelete={false}
             />
           </div>
-        </div>
-        <div className="w-full">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Gender
-          </div>
+        </InputLayout>
+        {/* 성별 선택 */}
+        <InputLayout title="Gender" isEssential={true}>
           <div className="w-full flex flex-row gap-[1.75rem]">
             {gender.map((gender) => (
               <RadioButton
@@ -135,12 +125,9 @@ const InformationStep = ({
               />
             ))}
           </div>
-        </div>
+        </InputLayout>
         {/* 생년월일 선택 */}
-        <div className="w-full">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Date of birth
-          </div>
+        <InputLayout title="Date of birth" isEssential={false} isOptional>
           <Dropdown
             value={newUserInfo.birth}
             placeholder="Select Date"
@@ -150,12 +137,9 @@ const InformationStep = ({
               setNewUserInfo({ ...newUserInfo, birth: value })
             }
           />
-        </div>
+        </InputLayout>
         {/* 국적 선택 */}
-        <div className="w-full">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Nationality
-          </div>
+        <InputLayout title="Nationality" isEssential={false} isOptional>
           <Dropdown
             value={newUserInfo.nationality}
             placeholder="Select Nationality"
@@ -164,12 +148,9 @@ const InformationStep = ({
               setNewUserInfo({ ...newUserInfo, nationality: value })
             }
           />
-        </div>
+        </InputLayout>
         {/* 비자 선택 */}
-        <div className="w-full mb-[7.125rem]">
-          <div className="w-full flex items-center justify-start body-3 color-[#222] px-[0.25rem] py-[0.375rem]">
-            Visa Status
-          </div>
+        <InputLayout title="Visa Status" isEssential>
           <Dropdown
             value={newUserInfo.visa}
             placeholder="Select Visa Status"
@@ -178,7 +159,7 @@ const InformationStep = ({
               setNewUserInfo({ ...newUserInfo, visa: value })
             }
           />
-        </div>
+        </InputLayout>
       </div>
       {/* 정보 입력 시마다 유효성을 검사해 모든 값이 유효하면 버튼이 활성화 */}
       <BottomButtonPanel>

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -35,24 +35,33 @@ const InformationStep = ({
 
   /* 정보 입력 시마다 유효성을 검사해 모든 값이 유효하면 버튼이 활성화 */
   useEffect(() => {
-    const { first_name, last_name, birth, nationality, visa } = newUserInfo;
+    const { first_name, last_name, visa, birth } = newUserInfo;
 
-    const isFormValid =
+    // 1. 필수 요소들 검증
+    const isEssentialValid =
       isValidName(String(first_name)) &&
       isValidName(String(last_name)) &&
-      birth !== '' &&
-      nationality !== '' &&
       visa !== '' &&
       isValidPhoneNumber(phoneNum);
 
-    if (isFormValid) {
-      setNewUserInfo((prevInfo) => ({
-        ...prevInfo,
-        phone_number: formatPhoneNumber(phoneNum),
-      }));
+    // 필수 요소가 하나라도 유효하지 않으면 여기서 종료
+    if (!isEssentialValid) {
+      setIsInvalid(true);
+      return;
     }
 
-    setIsInvalid(!isFormValid);
+    // 2. 선택 요소들 검증
+    const isOptionalValid =
+      // 빈칸이거나 유효한 값인 경우 true
+      birth === '' || Date.parse(birth as string) < Date.now();
+
+    if (!isOptionalValid) {
+      setIsInvalid(false);
+      return;
+    }
+
+    // 3. 모든 검증을 통과했을 때만 state 업데이트
+    setIsInvalid(false);
   }, [newUserInfo, phoneNum]);
 
   return (
@@ -184,6 +193,7 @@ const InformationStep = ({
                               .toUpperCase()
                               .replace(/\s/g, '_'),
                       birth: formatDateToDash(newUserInfo.birth as string),
+                      phone_number: formatPhoneNumber(phoneNum),
                       visa:
                         newUserInfo.visa !== null
                           ? newUserInfo.visa.replace(/-/g, '_')

--- a/src/components/WorkExperience/InputLayout.tsx
+++ b/src/components/WorkExperience/InputLayout.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 type InputLayOutProps = {
   title: string;
   isEssential: boolean;
+  isOptional?: boolean; // isOptional 속성 추가
   width?: string; // width 속성 string 전달
   children: ReactNode;
 };
@@ -11,14 +12,18 @@ const InputLayout = ({
   title,
   children,
   isEssential,
+  isOptional,
   width,
 }: InputLayOutProps) => {
   return (
     <div>
-      <p className={`${width} body-3 text-[#1E1926] px-1 py-2`}>
+      <p className={`${width} button-2 text-[#1E1926] px-1 py-[6px]`}>
         {title}
         {isEssential && (
           <span className="text-[#EE4700] body-1 ml-[0.125rem]">*</span>
+        )}
+        {isOptional && (
+          <span className="text-[#9397a1] body-3 pl-1">(optional)</span>
         )}
       </p>
       {children}

--- a/src/pages/Information/InformationPage.tsx
+++ b/src/pages/Information/InformationPage.tsx
@@ -9,7 +9,6 @@ import LanguageStep from '@/components/Information/LanguageStep';
 import PolicyViewer from '@/components/Information/PolicyViewer';
 import StepIndicator from '@/components/Information/StepIndicator';
 import { useGetPolicy, useSignUp } from '@/hooks/api/useAuth';
-//import { useSignUp } from '@/hooks/api/useAuth';
 import {
   initialUserInfoRequestBody,
   Language,
@@ -82,7 +81,11 @@ const InformationPage = () => {
             hasBackButton={true}
             hasMenuButton={false}
             title="Information"
-            onClickBackButton={() => navigate('/signup')}
+            onClickBackButton={() =>
+              currentStep === 1
+                ? navigate('/signup')
+                : setCurrentStep((prev) => prev - 1)
+            }
           />
           <div className="w-full flex flex-row px-4 py-8 items-center justify-between">
             <div

--- a/src/pages/Information/InformationPage.tsx
+++ b/src/pages/Information/InformationPage.tsx
@@ -69,7 +69,7 @@ const InformationPage = () => {
     });
   };
   return (
-    <div className="m-auto max-w-[500px] relative h-screen flex flex-col items-center justify-start border border-black overflow-y-scroll scrollbar-hide">
+    <div className="m-auto max-w-[500px] relative h-screen flex flex-col items-center justify-start overflow-y-scroll scrollbar-hide">
       {devIsModal ? (
         <CompleteModal
           title="Registration has been successfully completed"

--- a/src/pages/Information/InformationPage.tsx
+++ b/src/pages/Information/InformationPage.tsx
@@ -1,5 +1,6 @@
 import BottomSheetLayout from '@/components/Common/BottomSheetLayout';
 import CompleteModal from '@/components/Common/CompleteModal';
+import BaseHeader from '@/components/Common/Header/BaseHeader';
 import LoadingItem from '@/components/Common/LoadingItem';
 import AgreeModalInner from '@/components/Employer/Signup/AgreeModalInner';
 import AddressStep from '@/components/Information/AddressStep';
@@ -77,16 +78,22 @@ const InformationPage = () => {
         />
       ) : (
         <>
-          <div className="w-full flex flex-row py-6 items-center justify-between">
+          <BaseHeader
+            hasBackButton={true}
+            hasMenuButton={false}
+            title="Information"
+            onClickBackButton={() => navigate('/signup')}
+          />
+          <div className="w-full flex flex-row px-4 py-8 items-center justify-between">
             <div
-              className="relative w-full flex items-center justify-center title-1 text-[#1e1926] text-left"
+              className="relative w-full flex items-center justify-start head-2 text-[#1e1926]"
               onClick={() => setCurrentStep(currentStep + 1)}
             >
               Information
             </div>
             <StepIndicator length={3} currentStep={currentStep} />
           </div>
-          <div className="w-full flex justify-center px-6">
+          <div className="w-full flex justify-center px-4 pt-4">
             {currentStep === 1 && (
               <InformationStep userInfo={userInfo} onNext={handleNext} />
             )}

--- a/src/utils/information.ts
+++ b/src/utils/information.ts
@@ -1,10 +1,10 @@
 // Regular expression for first name validation
 // Allows 1-50 characters, only letters (no numbers or special characters)
-export const firstNameRegex = /^[A-Za-z]{1,50}$/;
+export const firstNameRegex = /^[A-Za-z가-힣]{1,50}$/;
 
 // Regular expression for last name validation
 // Allows 1-100 characters, only letters (no numbers or special characters)
-export const lastNameRegex = /^[A-Za-z]{1,100}$/;
+export const lastNameRegex = /^[A-Za-z가-힣]{1,50}$/;
 
 // Function to test if a string matches the first name criteria
 export const isValidFirstName = (name: string): boolean => {


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

#172 

## Work Description ✏️

- 유학생 회원가입 중 생년월일, 국적, 주소를 선택 입력 사항으로 적용
- 주소 검색, 선택 후 지도, 상세 주소 입력 란이 출현하는 로직으로 변경
- 회원가입 중 뒤로가기 기능 추가(정보 입력 step 간 이동 가능)
<img width="300" src="https://github.com/user-attachments/assets/87106076-fb6c-4147-91f3-aa68c3eb463d" />
<img width="300" src="https://github.com/user-attachments/assets/c3ea1a99-faed-466f-8182-af5302c5b667" />

## Uncompleted Tasks 😅

## To Reviewers 📢
선택사항 미입력 상태로 회원가입 테스트 완료했습니다.
+ 배포 버전에 상세 주소 유효성 검사 코드를 잘못 작성해서 상세 주소 자체를 입력할 수 없었던 현상 역시 수정해 적용했습니다.