### PR TITLE
[Fix/199] BottomSheet가 화면이 로드되는 동시에 안나타나는 오류

### DIFF
--- a/src/components/Common/BottomSheetLayout.tsx
+++ b/src/components/Common/BottomSheetLayout.tsx
@@ -23,13 +23,13 @@ const BottomSheetLayout = ({
 }: BottomSheetLayoutProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
-  const { setIsOpen, onDragEnd, controls, viewHeight } =
+  const { isOpen, setIsOpen, onDragEnd, controls, viewHeight } =
     useBottomSheet(setIsShowBottomSheet);
   const [contentHeight, setContentHeight] = useState<number>(0);
 
   useEffect(() => {
-    if (setIsShowBottomSheet) setIsOpen(isShowBottomsheet);
-  }, [isShowBottomsheet, setIsShowBottomSheet, setIsOpen]);
+    setIsOpen(isShowBottomsheet);
+  }, [isShowBottomsheet, setIsOpen]);
 
   // children의 height를 계산
   useEffect(() => {
@@ -40,18 +40,17 @@ const BottomSheetLayout = ({
   }, [children]);
 
   useEffect(() => {
-    if (isShowBottomsheet && isFixedBackground)
-      document.body.style.overflow = 'hidden';
+    if (isOpen && isFixedBackground) document.body.style.overflow = 'hidden';
     else document.body.style.overflow = 'auto';
 
     return () => {
       document.body.style.overflow = 'auto';
     };
-  }, [isShowBottomsheet, isFixedBackground]);
+  }, [isOpen, isFixedBackground]);
 
   return (
     <>
-      {isShowBottomsheet && isFixedBackground && (
+      {isOpen && isFixedBackground && (
         <div className="fixed w-screen h-screen top-0 bottom-0 left-0 right-0 bg-[rgba(0,0,0,0.3)] z-40"></div>
       )}
       <motion.div

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -36,7 +36,7 @@ const useBottomSheet = (
     }
   }, [controls, isOpen, prevIsOpen]);
 
-  return { onDragEnd, controls, setIsOpen, viewHeight };
+  return { onDragEnd, controls, isOpen, setIsOpen, viewHeight };
 };
 
 export default useBottomSheet;


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #199 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- BottomSheet가 화면이 로드되는 동시에 나타나야되는 경우를 고려못하고 이전에 BottomSheetLayout을 수정해서 발생한 오류였습니다ㅠㅠ


https://github.com/user-attachments/assets/aa8739f3-998e-45f4-80ec-0a2c4db17b56



## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
