### PR TITLE
[fix/217] 근로 계약서 작성 시에 Detailed Address에 입력이 불가능한 이슈 해결하기

### DIFF
--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -318,8 +318,8 @@ const IntegratedApplicationWriteForm = ({
                 placeholder="ex) 101-dong"
                 value={newDocumentData.address.address_detail}
                 onChange={(value) =>
-                  newDocumentData.address.address_detail &&
-                  newDocumentData.address.address_detail.trim().length < 100 &&
+                  value &&
+                  value.trim().length < 100 &&
                   setNewDocumentData({
                     ...newDocumentData,
                     address: {

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -255,8 +255,8 @@ const LaborContractWriteForm = ({
                 placeholder="ex) 101-dong"
                 value={newDocumentData.address.address_detail}
                 onChange={(value) =>
-                  newDocumentData.address.address_detail &&
-                  newDocumentData.address.address_detail.trim().length < 100 &&
+                  value &&
+                  value.trim().length < 100 &&
                   setNewDocumentData({
                     ...newDocumentData,
                     address: {


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #217

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 근로 계약서 작성 시에 Detailed Address에 입력이 불가능한 이슈 해결하기

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

제가 실수로 커밋 메세지 내용을 잘못입력했습니다ㅠㅠ 죄송합니다ㅠㅠ
필수 입력인데 입력이 불가능한 버그라서 우선은 바로 main에 반영하겠습니다!
