### PR TITLE
[Fix/257] - 공고 등록/수정 시 페이지 이동 로직 통일

### DIFF
--- a/src/hooks/api/usePost.ts
+++ b/src/hooks/api/usePost.ts
@@ -15,6 +15,7 @@ import {
   getRecommendPostList,
   putPostBookmark,
 } from '@/api/post';
+import { RESTYPE } from '@/types/api/common';
 import {
   GetApplyPostListReqType,
   GetEmployerPostListReqType,
@@ -23,6 +24,7 @@ import {
 import {
   useInfiniteQuery,
   useMutation,
+  UseMutationOptions,
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
@@ -173,42 +175,32 @@ export const useGetPostSummary = (id: number, isEnabled: boolean) => {
 };
 
 // 4.10 (고용주) 공고 등록하기 훅
-export const useCreatePost = (updateCurrentPostId: (id: number) => void) => {
-  const navigate = useNavigate();
-
+export const useCreatePost = (
+  options?: UseMutationOptions<RESTYPE<{ id: number }>, Error, FormData>,
+) => {
   return useMutation({
     mutationFn: createPost,
-    onSuccess: (response) => {
-      // response는 API 응답 데이터
-      // { success: true, data: { id: Long }, error: null }
-      updateCurrentPostId(Number(response.data.id));
-
-      setTimeout(() => {
-        navigate(`/employer/post/${response.data.id}`);
-      }, 1000);
-    },
     onError: (error) => {
       console.error('공고 등록하기 실패', error);
     },
+    ...options,
   });
 };
 
 // 4.10 (고용주) 공고 수정하기 훅
-export const useEditPost = (id: number) => {
-  const navigate = useNavigate();
-
+export const useEditPost = (
+  options?: UseMutationOptions<
+    RESTYPE<{ id: number }>,
+    Error,
+    { newPost: FormData; id: number }
+  >,
+) => {
   return useMutation({
     mutationFn: editPost,
-    onSuccess: () => {
-      // response는 API 응답 데이터
-      // { success: true, data: { id: Long }, error: null }
-      setTimeout(() => {
-        navigate(`/employer/post/${id}`);
-      }, 1000);
-    },
     onError: (error) => {
       console.error('공고 수정하기 실패', error);
     },
+    ...options,
   });
 };
 

--- a/src/pages/Employer/Post/EmployerCreatePostPage.tsx
+++ b/src/pages/Employer/Post/EmployerCreatePostPage.tsx
@@ -45,7 +45,6 @@ const EmployerCreatePostPage = () => {
   // 최종 완료 시 호출, 서버 api 호출 및 완료 modal 표시
   const handleSubmit = (newPost: FormData) => {
     mutate(newPost);
-    setDevIsModal(true);
   };
   return (
     <div>

--- a/src/pages/Employer/Post/EmployerCreatePostPage.tsx
+++ b/src/pages/Employer/Post/EmployerCreatePostPage.tsx
@@ -26,9 +26,14 @@ const EmployerCreatePostPage = () => {
   const [postInfo, setPostInfo] = useState<JobPostingForm>(
     initialJobPostingState,
   );
-
-  const { mutate } = useCreatePost(updateCurrentPostId); // 공고 생성 시 호출하느 ㄴ훅
   const [devIsModal, setDevIsModal] = useState(false);
+
+  const { mutate } = useCreatePost({
+    onSuccess: (response) => {
+      updateCurrentPostId(Number(response.data.id));
+      setDevIsModal(true);
+    },
+  }); // 공고 생성 시 호출하는 훅
 
   const navigate = useNavigate(); // navigate 변수를 정의합니다.
 

--- a/src/pages/Employer/Post/EmployerEditPostPage.tsx
+++ b/src/pages/Employer/Post/EmployerEditPostPage.tsx
@@ -29,7 +29,11 @@ const EmployerEditPostPage = () => {
   );
 
   const { data, isPending } = useGetPostDetail(Number(id), true);
-  const { mutate: editPost } = useEditPost(Number(currentPostId)); //  공고 수정 시 호출하는 훅
+  const { mutate: editPost } = useEditPost({
+    onSuccess: () => {
+      setDevIsModal(true);
+    },
+  }); //  공고 수정 시 호출하는 훅
   const [devIsModal, setDevIsModal] = useState(false);
   const [isDataMapped, setIsDataMapped] = useState(false);
   const navigate = useNavigate();
@@ -128,7 +132,7 @@ const EmployerEditPostPage = () => {
       {devIsModal ? (
         <CompleteModal
           title="공고 수정을 완료했어요!"
-          onNext={() => {}} // 생성한 공고에 대한 공고 상세 페이지로 이동 요망
+          onNext={() => navigate('/employer/post')}
         />
       ) : (
         <>

--- a/src/pages/Employer/Post/EmployerEditPostPage.tsx
+++ b/src/pages/Employer/Post/EmployerEditPostPage.tsx
@@ -47,7 +47,6 @@ const EmployerEditPostPage = () => {
   const handleSubmit = (newPost: FormData) => {
     if (isEdit) {
       editPost({ newPost: newPost, id: Number(id) });
-      setDevIsModal(true);
     }
   };
 


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #257

## Work Description ✏️

- 공고 등록/수정 api와 등록/수정 완료 슬라이드에 각각 산재해 있던 페이지 이동 로직을 통합했습니다.

<img width="376" alt="이름" src="https://github.com/user-attachments/assets/7809ade0-a9c9-48fc-981c-05ec6de6850e" />

## Uncompleted Tasks 😅

## To Reviewers 📢

이슈별로 "254-task-request---mutation-api-로딩-스피너-적용" 브랜치에서 분기해 작업, 통합 후 dev에 merge 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게시물 생성 및 편집 시, 작업이 성공적으로 완료되었을 때만 알림 모달이 표시되어 사용자 경험이 향상되었습니다.
	- 편집 완료 후에는 자동으로 게시물 목록 페이지로 전환됩니다.
- **리팩터**
	- 게시물 생성 및 편집 동작의 옵션 처리 방식을 개선하여, 보다 유연하게 성공 처리 로직을 관리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->