### PR TITLE
[Feature/256] - 공고 등록수정 시 이미지 복수 선택 가능

### DIFF
--- a/src/components/Employer/PostCreate/Step4.tsx
+++ b/src/components/Employer/PostCreate/Step4.tsx
@@ -7,7 +7,7 @@ import { buttonTypeKeys } from '@/constants/components';
 import { phone } from '@/constants/information';
 import { InputType } from '@/types/common/input';
 import type { Image, JobPostingForm } from '@/types/postCreate/postCreate';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import AddFileIcon from '@/assets/icons/FileAddIcon.svg?react';
 import {
   formatPhoneNumber,
@@ -70,11 +70,28 @@ const Step4 = ({
   }, [newPostInfo, phoneNum]);
 
   // 이미지 선택
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const newFiles = newPostInfo.images as File[];
-      newFiles.push(file);
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    // 현재 이미지와 새 이미지의 총 개수가 10개를 초과하는지 확인
+    const currentImageCount = newPostInfo.images.length;
+    const newFilesCount = files.length;
+    const totalCount = currentImageCount + newFilesCount;
+
+    // 10개 제한 처리
+    if (totalCount > 10) {
+      alert('이미지는 최대 10개까지만 업로드할 수 있습니다.');
+      const availableSlots = 10 - currentImageCount;
+      const filesToAdd = Array.from(files).slice(0, availableSlots);
+
+      const newFiles = [...newPostInfo.images] as File[];
+      filesToAdd.forEach((file) => newFiles.push(file));
+      setNewPostInfo({ ...newPostInfo, images: newFiles });
+    } else {
+      // 모든 파일 추가
+      const newFiles = [...newPostInfo.images] as File[];
+      Array.from(files).forEach((file) => newFiles.push(file));
       setNewPostInfo({ ...newPostInfo, images: newFiles });
     }
   };
@@ -144,7 +161,7 @@ const Step4 = ({
           <div className="w-full relative body-3 px-1 pb-1.5 text-[#222] text-left">
             사진이 있으면 관심 확률이 올라가요 !
           </div>
-          <div className="w-full overflow-x-scroll flex gap-2 item-center justify-start">
+          <div className="w-full overflow-x-scroll no-scrollbar flex gap-2 item-center justify-start">
             {newPostInfo.images.length < 10 && (
               <label className="cursor-pointer" htmlFor="logo-upload">
                 <div className="w-[7.5rem] h-[7.5rem] rounded-lg flex items-center justify-center shadow-sm bg-white border border-[#eae9f6] px-4 py-2.5">
@@ -156,6 +173,7 @@ const Step4 = ({
                   accept="image/jpeg,image/png"
                   onChange={handleImageChange}
                   className="hidden"
+                  multiple
                 />
               </label>
             )}

--- a/src/hooks/api/usePost.ts
+++ b/src/hooks/api/usePost.ts
@@ -15,6 +15,7 @@ import {
   getRecommendPostList,
   putPostBookmark,
 } from '@/api/post';
+import { RESTYPE } from '@/types/api/common';
 import {
   GetApplyPostListReqType,
   GetEmployerPostListReqType,
@@ -23,6 +24,7 @@ import {
 import {
   useInfiniteQuery,
   useMutation,
+  UseMutationOptions,
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
@@ -173,42 +175,32 @@ export const useGetPostSummary = (id: number, isEnabled: boolean) => {
 };
 
 // 4.10 (고용주) 공고 등록하기 훅
-export const useCreatePost = (updateCurrentPostId: (id: number) => void) => {
-  const navigate = useNavigate();
-
+export const useCreatePost = (
+  options?: UseMutationOptions<RESTYPE<{ id: number }>, Error, FormData>,
+) => {
   return useMutation({
     mutationFn: createPost,
-    onSuccess: (response) => {
-      // response는 API 응답 데이터
-      // { success: true, data: { id: Long }, error: null }
-      updateCurrentPostId(Number(response.data.id));
-
-      setTimeout(() => {
-        navigate(`/employer/post/${response.data.id}`);
-      }, 1000);
-    },
     onError: (error) => {
       console.error('공고 등록하기 실패', error);
     },
+    ...options,
   });
 };
 
 // 4.10 (고용주) 공고 수정하기 훅
-export const useEditPost = (id: number) => {
-  const navigate = useNavigate();
-
+export const useEditPost = (
+  options?: UseMutationOptions<
+    RESTYPE<{ id: number }>,
+    Error,
+    { newPost: FormData; id: number }
+  >,
+) => {
   return useMutation({
     mutationFn: editPost,
-    onSuccess: () => {
-      // response는 API 응답 데이터
-      // { success: true, data: { id: Long }, error: null }
-      setTimeout(() => {
-        navigate(`/employer/post/${id}`);
-      }, 1000);
-    },
     onError: (error) => {
       console.error('공고 수정하기 실패', error);
     },
+    ...options,
   });
 };
 

--- a/src/pages/Employer/Post/EmployerCreatePostPage.tsx
+++ b/src/pages/Employer/Post/EmployerCreatePostPage.tsx
@@ -45,7 +45,6 @@ const EmployerCreatePostPage = () => {
   // 최종 완료 시 호출, 서버 api 호출 및 완료 modal 표시
   const handleSubmit = (newPost: FormData) => {
     mutate(newPost);
-    setDevIsModal(true);
   };
   return (
     <div>

--- a/src/pages/Employer/Post/EmployerCreatePostPage.tsx
+++ b/src/pages/Employer/Post/EmployerCreatePostPage.tsx
@@ -26,9 +26,14 @@ const EmployerCreatePostPage = () => {
   const [postInfo, setPostInfo] = useState<JobPostingForm>(
     initialJobPostingState,
   );
-
-  const { mutate } = useCreatePost(updateCurrentPostId); // 공고 생성 시 호출하느 ㄴ훅
   const [devIsModal, setDevIsModal] = useState(false);
+
+  const { mutate } = useCreatePost({
+    onSuccess: (response) => {
+      updateCurrentPostId(Number(response.data.id));
+      setDevIsModal(true);
+    },
+  }); // 공고 생성 시 호출하는 훅
 
   const navigate = useNavigate(); // navigate 변수를 정의합니다.
 

--- a/src/pages/Employer/Post/EmployerEditPostPage.tsx
+++ b/src/pages/Employer/Post/EmployerEditPostPage.tsx
@@ -29,7 +29,11 @@ const EmployerEditPostPage = () => {
   );
 
   const { data, isPending } = useGetPostDetail(Number(id), true);
-  const { mutate: editPost } = useEditPost(Number(currentPostId)); //  공고 수정 시 호출하는 훅
+  const { mutate: editPost } = useEditPost({
+    onSuccess: () => {
+      setDevIsModal(true);
+    },
+  }); //  공고 수정 시 호출하는 훅
   const [devIsModal, setDevIsModal] = useState(false);
   const [isDataMapped, setIsDataMapped] = useState(false);
   const navigate = useNavigate();
@@ -128,7 +132,7 @@ const EmployerEditPostPage = () => {
       {devIsModal ? (
         <CompleteModal
           title="공고 수정을 완료했어요!"
-          onNext={() => {}} // 생성한 공고에 대한 공고 상세 페이지로 이동 요망
+          onNext={() => navigate('/employer/post')}
         />
       ) : (
         <>

--- a/src/pages/Employer/Post/EmployerEditPostPage.tsx
+++ b/src/pages/Employer/Post/EmployerEditPostPage.tsx
@@ -47,7 +47,6 @@ const EmployerEditPostPage = () => {
   const handleSubmit = (newPost: FormData) => {
     if (isEdit) {
       editPost({ newPost: newPost, id: Number(id) });
-      setDevIsModal(true);
     }
   };
 


### PR DESCRIPTION
## Related issue 🛠

- closed #256 

## Work Description ✏️

- 공고 등록/수정 시 이미지를 다중 선택/첨부 가능하도록 수정
  - 이미지 첨부 시 10장 초과할 경우, alert 후 10장까지만 첨부
  - 다수의 이미지 첨부 후 y축 스크롤 바 출현하지 않도록 수정

<img width="376" alt="이미지다중선택기능시연영상" src="https://github.com/user-attachments/assets/1bebe669-51be-4e41-a041-27eb374ab654" />

## Uncompleted Tasks 😅

## To Reviewers 📢

#256 태그가 있는 커밋만 리뷰해주시면 됩니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 이미지 업로드 기능이 개선되어, 한 번에 여러 이미지를 선택할 수 있으며 최대 10개로 제한되고, 제한 초과 시 사용자에게 알림을 제공합니다.
  - 포스트 생성 및 수정 시, 성공적으로 처리된 후 모달 창이 표시되며, 후속 화면으로 원활하게 이동하는 흐름을 도입했습니다.

- **Style**
  - 일부 화면 구성 요소의 레이아웃 및 스크롤 관련 스타일이 미세하게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->