### PR TITLE
✨ feat: 앱으로부터 메시지 수신 및 핸들링 로직 작성 #265

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,10 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import axios from 'axios';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ServerErrorBottomSheet from '@/components/Common/ServerErrorBottomSheet';
 import { LoadingOverLay } from '@/components/Common/LoadingItem';
+import { setupReactNativeMessageListener } from '@/utils/reactNativeMessage';
 
 function App() {
   const [isOpenErrorBottomSheet, setIsOpenErrorBottomSheet] = useState(false);
@@ -42,6 +43,15 @@ function App() {
       }),
   );
 
+  useEffect(() => {
+    const cleanup = setupReactNativeMessageListener((data) => {
+      if (data.type === 'FCMTOKEN') {
+        // FCM 토큰을 받아서 서버로 전송
+      }
+    });
+
+    return cleanup;
+  }, []);
   return (
     <QueryClientProvider client={queryClient}>
       <Router />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,10 +10,12 @@ import { useEffect, useState } from 'react';
 import ServerErrorBottomSheet from '@/components/Common/ServerErrorBottomSheet';
 import { LoadingOverLay } from '@/components/Common/LoadingItem';
 import { setupReactNativeMessageListener } from '@/utils/reactNativeMessage';
+import { usePatchDeviceToken } from '@/hooks/api/useAuth';
 
 function App() {
   const [isOpenErrorBottomSheet, setIsOpenErrorBottomSheet] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const { mutate: patchDeviceToken } = usePatchDeviceToken();
 
   const openErrorBottomSheet = (error: unknown) => {
     if (!axios.isAxiosError(error)) return;
@@ -45,8 +47,8 @@ function App() {
 
   useEffect(() => {
     const cleanup = setupReactNativeMessageListener((data) => {
-      if (data.type === 'FCMTOKEN') {
-        // FCM 토큰을 받아서 서버로 전송
+      if (data.type === 'FCMTOKEN' && data.payload !== undefined) {
+        patchDeviceToken(data.payload);
       }
     });
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -75,6 +75,16 @@ export const reIssueToken = async (
   return response.data;
 };
 
+// 1.4 (유학생/고용주) 디바이스 토큰 갱신하기
+export const patchDeviceToken = async (
+  deviceToken: string,
+): Promise<RESTYPE<null>> => {
+  const response = await api.patch('/auth/device-token', {
+    device_token: deviceToken,
+  });
+  return response.data;
+};
+
 // 2.1 아이디 중복검사
 export const getIdValidation = async (
   userId: string,

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -15,6 +15,7 @@ import {
   reIssuePassword,
   patchPassword,
   postRegistrationNumberValidation,
+  patchDeviceToken,
 } from '@/api/auth';
 import {
   AuthenticationResponse,
@@ -46,6 +47,7 @@ import { TermType } from '@/types/api/users';
 import { AxiosError } from 'axios';
 import { useUserStore } from '@/store/user';
 import { UserType } from '@/constants/user';
+import { sendReactNativeMessage } from '@/utils/reactNativeMessage';
 
 /**
  * 로그인 프로세스를 처리하는 커스텀 훅
@@ -84,7 +86,8 @@ export const useSignIn = () => {
 
         updateId('');
         updatePassword('');
-
+        // 앱에서 FCM 토큰 요청
+        sendReactNativeMessage({ type: 'RECEIVE_TOKEN' });
         navigate('/splash');
         window.location.reload();
       }
@@ -127,12 +130,24 @@ export const useReIssueToken = () => {
       if (data.success) {
         setAccessToken(data.data.access_token);
         setRefreshToken(data.data.refresh_token);
-        navigate('/splash'); // 재발급 후 유형 확인
+        // 앱에서 FCM 토큰 요청
+        sendReactNativeMessage({ type: 'RECEIVE_TOKEN' });
+        navigate('/splash');
       }
     },
     onError: () => {
       alert('만료되었습니다. 다시 로그인해주세요.');
       navigate('/signin');
+    },
+  });
+};
+
+// 1.4 디바이스 토큰 갱신 훅
+export const usePatchDeviceToken = () => {
+  return useMutation({
+    mutationFn: patchDeviceToken,
+    onError: () => {
+      console.error('디바이스 토큰 갱신에 실패했습니다.');
     },
   });
 };


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #265 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 앱에서 웹으로 전송한 메시지 핸들링 로직 작성

https://github.com/user-attachments/assets/c1587430-671e-4702-bca8-4e4ee3cb7f50


## Uncompleted Tasks 😅

- [ ] 앱에서 fcm 토큰을 실제로 get 해 웹으로 전송

## To Reviewers 📢
원래는 isMobile, isAndroid, isIos 등을 사용해 구분하려 했으나 시뮬레이터 환경은 `window.ReactNativeWebview` 만 존재할 뿐 isMobile, isAndroid, isIos 를 전부 false가 반환되어 플랫폼에 상관없이 이벤트 리스너를 추가하는 방식으로 변경했습니다.

시연 영상은 앱에서 fcm 토큰이라 가정, 웹으로 전송한 텍스트를 웹에서 `alert()` 함수로 화면에 표시하는 과정입니다.

리뷰 후 #268 를 확인해주시면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 모바일 알림(FCM) 토큰 처리를 위한 메시지 수신 기능이 추가되어, 앱이 알림 관련 메시지를 보다 원활하게 처리합니다.
  - 디바이스 토큰을 업데이트하는 비동기 함수가 추가되어, 사용자 디바이스의 알림 수신을 향상시킵니다.

- **리팩터링**
  - 메시지 이벤트 처리 로직을 개선하여, 데이터 파싱, 오류 처리 및 이벤트 정리 과정이 한층 더 안정적으로 동작하도록 개선하였습니다.
  - 디바이스 토큰 관리와 관련된 훅을 추가하여, 로그인 및 토큰 재발급 프로세스를 개선하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->