### PR TITLE
✨ feat: 디바이스 fcm 토큰 등록 로직 구현 #266

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,10 +10,12 @@ import { useEffect, useState } from 'react';
 import ServerErrorBottomSheet from '@/components/Common/ServerErrorBottomSheet';
 import { LoadingOverLay } from '@/components/Common/LoadingItem';
 import { setupReactNativeMessageListener } from '@/utils/reactNativeMessage';
+import { usePatchDeviceToken } from '@/hooks/api/useAuth';
 
 function App() {
   const [isOpenErrorBottomSheet, setIsOpenErrorBottomSheet] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const { mutate: patchDeviceToken } = usePatchDeviceToken();
 
   const openErrorBottomSheet = (error: unknown) => {
     if (!axios.isAxiosError(error)) return;
@@ -45,8 +47,8 @@ function App() {
 
   useEffect(() => {
     const cleanup = setupReactNativeMessageListener((data) => {
-      if (data.type === 'FCMTOKEN') {
-        // FCM 토큰을 받아서 서버로 전송
+      if (data.type === 'FCMTOKEN' && data.payload !== undefined) {
+        patchDeviceToken(data.payload);
       }
     });
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -75,6 +75,16 @@ export const reIssueToken = async (
   return response.data;
 };
 
+// 1.4 (유학생/고용주) 디바이스 토큰 갱신하기
+export const patchDeviceToken = async (
+  deviceToken: string,
+): Promise<RESTYPE<null>> => {
+  const response = await api.patch('/auth/device-token', {
+    device_token: deviceToken,
+  });
+  return response.data;
+};
+
 // 2.1 아이디 중복검사
 export const getIdValidation = async (
   userId: string,

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -15,6 +15,7 @@ import {
   reIssuePassword,
   patchPassword,
   postRegistrationNumberValidation,
+  patchDeviceToken,
 } from '@/api/auth';
 import {
   AuthenticationResponse,
@@ -46,6 +47,7 @@ import { TermType } from '@/types/api/users';
 import { AxiosError } from 'axios';
 import { useUserStore } from '@/store/user';
 import { UserType } from '@/constants/user';
+import { sendReactNativeMessage } from '@/utils/reactNativeMessage';
 
 /**
  * 로그인 프로세스를 처리하는 커스텀 훅
@@ -84,7 +86,8 @@ export const useSignIn = () => {
 
         updateId('');
         updatePassword('');
-
+        // 앱에서 FCM 토큰 요청
+        sendReactNativeMessage({ type: 'RECEIVE_TOKEN' });
         navigate('/splash');
         window.location.reload();
       }
@@ -127,12 +130,24 @@ export const useReIssueToken = () => {
       if (data.success) {
         setAccessToken(data.data.access_token);
         setRefreshToken(data.data.refresh_token);
-        navigate('/splash'); // 재발급 후 유형 확인
+        // 앱에서 FCM 토큰 요청
+        sendReactNativeMessage({ type: 'RECEIVE_TOKEN' });
+        navigate('/splash');
       }
     },
     onError: () => {
       alert('만료되었습니다. 다시 로그인해주세요.');
       navigate('/signin');
+    },
+  });
+};
+
+// 1.4 디바이스 토큰 갱신 훅
+export const usePatchDeviceToken = () => {
+  return useMutation({
+    mutationFn: patchDeviceToken,
+    onError: () => {
+      console.error('디바이스 토큰 갱신에 실패했습니다.');
     },
   });
 };


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #266 

## Work Description ✏️

- 로그인/reissue 시 앱에 디바이스 Fcm 토큰 요청 및 갱신 로직 작성

## Uncompleted Tasks 😅

## To Reviewers 📢

#267 을 먼저 확인하시고 이 PR을 확인하시면 됩니다.

`useSignIn`, `useReissueToken` 훅의 `onSuccess` 핸들러에서 `sendReactNativeMessage()`를 호출, 앱에 fcm 토큰을 요청하고, 앱에서 `postMessage()` 로 보낸 토큰을 `App.tsx`의 `useEffect` 내부 cleanup 함수인 리스너가 감지, `usePatchDeviceToken` 훅을 호출해 서버에 등록합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 기기 등록 정보를 자동으로 업데이트하는 기능이 추가되어, 메시지 및 알림 전달의 안정성이 향상되었습니다.
  - 인증 및 토큰 갱신 시 기기 정보가 최신 상태로 유지되어 사용자 경험이 개선됩니다.

- **개선 사항**
  - 메시지 처리 로직이 보완되어, 올바른 데이터 기반의 알림 전송이 이루어지도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->