### PR TITLE
[Fix/269] tanstack query context error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,16 +6,14 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import axios from 'axios';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ServerErrorBottomSheet from '@/components/Common/ServerErrorBottomSheet';
 import { LoadingOverLay } from '@/components/Common/LoadingItem';
-import { setupReactNativeMessageListener } from '@/utils/reactNativeMessage';
-import { usePatchDeviceToken } from '@/hooks/api/useAuth';
+import { ReactNativeMessageListener } from '@/components/Common/ReactNativeMessageListener';
 
 function App() {
   const [isOpenErrorBottomSheet, setIsOpenErrorBottomSheet] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const { mutate: patchDeviceToken } = usePatchDeviceToken();
 
   const openErrorBottomSheet = (error: unknown) => {
     if (!axios.isAxiosError(error)) return;
@@ -45,17 +43,9 @@ function App() {
       }),
   );
 
-  useEffect(() => {
-    const cleanup = setupReactNativeMessageListener((data) => {
-      if (data.type === 'FCMTOKEN' && data.payload !== undefined) {
-        patchDeviceToken(data.payload);
-      }
-    });
-
-    return cleanup;
-  }, []);
   return (
     <QueryClientProvider client={queryClient}>
+      <ReactNativeMessageListener />
       <Router />
       {isOpenErrorBottomSheet && (
         <ServerErrorBottomSheet

--- a/src/components/Common/ReactNativeMessageListener.tsx
+++ b/src/components/Common/ReactNativeMessageListener.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { setupReactNativeMessageListener } from '@/utils/reactNativeMessage';
+import { usePatchDeviceToken } from '@/hooks/api/useAuth';
+
+export const ReactNativeMessageListener = () => {
+  const { mutate: patchDeviceToken } = usePatchDeviceToken();
+
+  useEffect(() => {
+    const cleanup = setupReactNativeMessageListener((data) => {
+      if (data.type === 'FCMTOKEN' && data.payload !== undefined) {
+        patchDeviceToken(data.payload);
+      }
+    });
+
+    return cleanup;
+  }, [patchDeviceToken]);
+
+  return null;
+};


### PR DESCRIPTION
## Related issue 🛠

- closed #269 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 기존 `App.tsx`에서 앱 메시지 리스너를 추가하던 `useEffect` 훅을 `ReactNativeMessageListener` 로 분리, QueryClientProvider 내부로 이동

## Uncompleted Tasks 😅

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 애플리케이션에 새로운 메시지 수신 컴포넌트를 추가하여, 관련 메시지 처리가 보다 체계적으로 이루어집니다.
  
- **리팩터**
  - 기존의 메시지 처리 구조를 개선하고 분리하여, 내부 로직의 효율성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->