### PR TITLE
Fix/277 - 유학생 문서 수정 시 공고 id를 보내는 현상

### DIFF
--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -29,7 +29,10 @@ import {
   formatPhoneNumber,
   parsePhoneNumber,
 } from '@/utils/information';
-import { useCurrentPostIdEmployeeStore } from '@/store/url';
+import {
+  useCurrentDocumentIdStore,
+  useCurrentPostIdEmployeeStore,
+} from '@/store/url';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import InputLayout from '../WorkExperience/InputLayout';
@@ -46,6 +49,7 @@ const IntegratedApplicationWriteForm = ({
   const [isInvalid, setIsInvalid] = useState(false);
   const [isAddressSearch, setIsAddressSearch] = useState<boolean>(false);
   const { currentPostId } = useCurrentPostIdEmployeeStore();
+  const { currentDocumentId } = useCurrentDocumentIdStore();
   const [newDocumentData, setNewDocumentData] =
     useState<IntegratedApplicationData>(initialIntegratedApplication);
 
@@ -148,7 +152,7 @@ const IntegratedApplicationWriteForm = ({
       new_work_place_phone_number: formatPhoneNumber(workPlacePhoneNum),
     };
     const payload = {
-      id: Number(currentPostId),
+      id: Number(isEdit ? currentDocumentId : currentPostId),
       document: finalDocument, // TODO: 로그인 연결 후 userId를 넣어야 하는 것으로 추정
     };
 

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -20,7 +20,7 @@ import {
   usePostStandardLaborContracts,
   usePutStandardLaborContracts,
 } from '@/hooks/api/useDocument';
-import { useCurrentPostIdEmployeeStore } from '@/store/url';
+import { useCurrentDocumentIdStore, useCurrentPostIdEmployeeStore } from '@/store/url';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import InputLayout from '../WorkExperience/InputLayout';
@@ -38,6 +38,7 @@ const LaborContractWriteForm = ({
   const [newDocumentData, setNewDocumentData] =
     useState<LaborContractEmployeeInfo>(initialLaborContractEmployeeInfo);
   const { currentPostId } = useCurrentPostIdEmployeeStore();
+  const { currentDocumentId } = useCurrentDocumentIdStore();
   // 세 부분으로 나누어 입력받는 방식을 위해 전화번호만 별도의 state로 분리, 추후 유효성 검사 단에서 통합
   const [phoneNum, setPhoneNum] = useState({
     start: '010',
@@ -93,7 +94,7 @@ const LaborContractWriteForm = ({
       phone_number: formatPhoneNumber(phoneNum),
     };
     const payload = {
-      id: Number(currentPostId),
+      id: Number(isEdit ? currentDocumentId : currentPostId),
       document: finalDocument, // TODO: 로그인 연결 후 userId를 넣어야 하는 것으로 추정
     };
 

--- a/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
+++ b/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
@@ -18,7 +18,10 @@ import {
   usePostPartTimeEmployPermit,
   usePutPartTimeEmployPermit,
 } from '@/hooks/api/useDocument';
-import { useCurrentPostIdEmployeeStore } from '@/store/url';
+import {
+  useCurrentDocumentIdStore,
+  useCurrentPostIdEmployeeStore,
+} from '@/store/url';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 
 type PartTimePermitFormProps = {
@@ -31,12 +34,13 @@ const PartTimePermitWriteForm = ({
   isEdit,
 }: PartTimePermitFormProps) => {
   const { currentPostId } = useCurrentPostIdEmployeeStore();
+  const { currentDocumentId } = useCurrentDocumentIdStore();
   const [newDocumentData, setNewDocumentData] =
     useState<PartTimePermitFormRequest>(initialPartTimePermitForm);
   const { mutate: postDocument, isPending: postPending } =
     usePostPartTimeEmployPermit(Number(currentPostId)); // 작성된 문서 제출 훅
   const { mutate: updateDocument, isPending: updatePending } =
-    usePutPartTimeEmployPermit(Number(currentPostId)); // 수정된 문서 제출 훅
+    usePutPartTimeEmployPermit(Number(currentDocumentId)); // 수정된 문서 제출 훅
   // 세 부분으로 나누어 입력받는 방식을 위해 전화번호만 별도의 state로 분리, 추후 유효성 검사 단에서 통합
   const [phoneNum, setPhoneNum] = useState({
     start: '010',
@@ -69,7 +73,7 @@ const PartTimePermitWriteForm = ({
       phone_number: formatPhoneNumber(phoneNum),
     };
     const payload = {
-      id: Number(currentPostId),
+      id: Number(isEdit ? currentDocumentId : currentPostId),
       document: finalDocument, // TODO: 로그인 연결 후 userId를 넣어야 하는 것으로 추정
     };
 

--- a/src/hooks/api/useDocument.ts
+++ b/src/hooks/api/useDocument.ts
@@ -98,6 +98,7 @@ export const usePutPartTimeEmployPermit = (
       navigate('/write-documents', {
         state: {
           type: DocumentType.PART_TIME_PERMIT,
+          isEdit: true,
         },
       }),
     ...options,
@@ -123,6 +124,7 @@ export const usePutPartTimeEmployPermitEmployer = (
       navigate('/write-documents', {
         state: {
           type: DocumentType.PART_TIME_PERMIT,
+          isEdit: true,
         },
       }),
     ...options,
@@ -173,6 +175,7 @@ export const usePutStandardLaborContracts = (
       navigate('/write-documents', {
         state: {
           type: DocumentType.LABOR_CONTRACT,
+          isEdit: true,
         },
       }),
     ...options,
@@ -198,6 +201,7 @@ export const usePutLaborContractEmployer = (
       navigate('/write-documents', {
         state: {
           type: DocumentType.LABOR_CONTRACT,
+          isEdit: true,
         },
       }),
     ...options,
@@ -249,6 +253,7 @@ export const usePutIntegratedApplicants = (
       navigate(`/write-documents/${id}`, {
         state: {
           type: DocumentType.INTEGRATED_APPLICATION,
+          isEdit: true,
         },
       }),
     ...options,


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #277 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 문서 수정 시 문서 id를 보내도록 수정
- 문서 수정 에러 발생 시 문서 수정 페이지로 돌아오도록 수정

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 문서 작성 및 편집 프로세스가 개선되어, 편집 모드일 경우 올바른 문서 ID가 자동으로 선택됩니다.
	- 오류 처리 시 편집 상태가 명확하게 반영되어, 문서 제출 과정의 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->