### PR TITLE
[Fix/280] - 문서 수정 전화번호 관련

### DIFF
--- a/src/components/Document/write/EmployeeInfoSection.tsx
+++ b/src/components/Document/write/EmployeeInfoSection.tsx
@@ -69,6 +69,15 @@ const EmployeeInfoSection = ({
             </div>
           </div>
         );
+      // 이메일은 첫 글자 대문자화 제외
+      case PartTimePermitFormProperty.EMAIL:
+        return (
+          <div className="w-full self-stretch flex items-start justify-start body-2 text-primary-dark">
+            {propertyToString(String(value)) === 'Null'
+              ? 'none'
+              : String(value)}
+          </div>
+        );
       default:
         return <DefaultValueRenderer value={value} />;
     }

--- a/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
+++ b/src/components/Employer/EditProfile/EmployerEditInputSection.tsx
@@ -16,6 +16,7 @@ import {
 import { EmployerProfileRequestBody } from '@/types/api/profile';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
+import { documentTranslation } from '@/constants/translation';
 
 type EmployerEditInputSectionProps = {
   newEmployData: EmployerProfileRequestBody;
@@ -231,6 +232,12 @@ const EmployerEditInputSection = ({
                   }
                   canDelete={false}
                 />
+                {newEmployData.address.address_detail &&
+                  newEmployData.address.address_detail.length > 50 && (
+                    <p className="text-[#FF6F61] text-xs p-2">
+                      {documentTranslation.detailAddressTooLong.ko}
+                    </p>
+                  )}
               </InputLayout>
             </div>
             {/* 사업자 등록번호 입력 */}

--- a/src/components/Employer/PostCreate/Step2.tsx
+++ b/src/components/Employer/PostCreate/Step2.tsx
@@ -12,6 +12,7 @@ import { buttonTypeKeys } from '@/constants/components';
 import { formatDateToDash } from '@/utils/editResume';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
+import { documentTranslation } from '@/constants/translation';
 
 const Step2 = ({
   postInfo,
@@ -79,7 +80,8 @@ const Step2 = ({
     const isFormValid =
       address.address_name !== '' &&
       address.address_detail &&
-      address.address_detail !== '';
+      address.address_detail !== '' &&
+      address.address_detail.length <= 50;
     // work_day_times.length &&
     setIsInvalid(!isFormValid);
   }, [newPostInfo]);
@@ -155,6 +157,12 @@ const Step2 = ({
                   }
                   canDelete={false}
                 />
+                {newPostInfo.body.address.address_detail &&
+                  newPostInfo.body.address.address_detail.length > 50 && (
+                    <p className="text-text-error text-xs p-2">
+                      {documentTranslation.detailAddressTooLong.ko}
+                    </p>
+                  )}
               </InputLayout>
             </div>
             {/* 날짜 선택 입력 */}

--- a/src/components/Employer/Signup/InformationInputSection.tsx
+++ b/src/components/Employer/Signup/InformationInputSection.tsx
@@ -15,7 +15,7 @@ import {
   formatPhoneNumber,
 } from '@/utils/information';
 import PageTitle from '@/components/Common/PageTitle';
-import { signInputTranclation } from '@/constants/translation';
+import { documentTranslation, signInputTranclation } from '@/constants/translation';
 import { isEmployer } from '@/utils/signup';
 import { useLocation } from 'react-router-dom';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
@@ -291,6 +291,12 @@ const InformationInputSection = ({
                     }
                     canDelete={false}
                   />
+                  {newEmployData.address.address_detail &&
+                    newEmployData.address.address_detail.length > 50 && (
+                      <p className="text-text-error text-xs p-2">
+                        {documentTranslation.detailAddressTooLong.ko}
+                      </p>
+                    )}
                 </InputLayout>
               </div>
               {/* 사업자 등록번호 입력 */}

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -24,6 +24,8 @@ import Button from '@/components/Common/Button';
 import { usePutLaborContractEmployer } from '@/hooks/api/useDocument';
 import {
   handleHourlyRateBlur,
+  parseStringToSafeDecimalNumber,
+  parseStringToSafeDecimalNumberText,
   parseStringToSafeNumber,
   validateLaborContractEmployerInformation,
 } from '@/utils/document';
@@ -67,6 +69,9 @@ const EmployerLaborContractForm = ({
       ? parsePhoneNumber(newDocumentData.phone_number).end
       : '',
   });
+  const [wageRateInput, setWageRateInput] = useState(
+    String(newDocumentData.wage_rate),
+  );
 
   const [isInvalid, setIsInvalid] = useState(false);
   // 근무시간, 요일 선택 모달 활성화 플래그
@@ -519,13 +524,18 @@ const EmployerLaborContractForm = ({
               <Input
                 inputType={InputType.TEXT}
                 placeholder="0"
-                value={String(newDocumentData.wage_rate)}
-                onChange={(value) =>
+                value={wageRateInput}
+                onChange={(value) => {
+                  const validText = parseStringToSafeDecimalNumberText(value);
+                  setWageRateInput(validText);
+
+                  // 소수점으로 끝나는 경우에도 일단 숫자로 변환 (소수점은 무시됨)
+                  const numValue = validText === '' ? 0 : Number(validText);
                   setNewDocumentData({
                     ...newDocumentData,
-                    wage_rate: parseStringToSafeNumber(value),
-                  })
-                }
+                    wage_rate: numValue,
+                  });
+                }}
                 canDelete={false}
                 isUnit
                 unit="%"

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -42,6 +42,7 @@ import CheckIcon from '@/assets/icons/CheckOfBoxIcon.svg?react';
 import { useCurrentDocumentIdStore } from '@/store/url';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
+import { documentTranslation } from '@/constants/translation';
 
 type LaborContractFormProps = {
   document?: LaborContractDataResponse;
@@ -337,6 +338,12 @@ const EmployerLaborContractForm = ({
                       }
                       canDelete={false}
                     />
+                    {newDocumentData.address.address_detail &&
+                      newDocumentData.address.address_detail.length > 50 && (
+                        <p className="text-text-error text-xs p-2">
+                          {documentTranslation.detailAddressTooLong.ko}
+                        </p>
+                      )}
                   </InputLayout>
                 </>
               )}

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -79,11 +79,15 @@ const EmployerLaborContractForm = ({
     if (isEdit && document?.employer_information) {
       setNewDocumentData(document?.employer_information);
       setPhoneNum({
-        start: parsePhoneNumber(document?.employee_information.phone_number)
-          .start,
-        middle: parsePhoneNumber(document?.employee_information.phone_number)
-          .middle,
-        end: parsePhoneNumber(document?.employee_information.phone_number).end,
+        start: parsePhoneNumber(
+          document?.employer_information.phone_number as string,
+        ).start,
+        middle: parsePhoneNumber(
+          document?.employer_information.phone_number as string,
+        ).middle,
+        end: parsePhoneNumber(
+          document?.employer_information.phone_number as string,
+        ).end,
       });
     }
   }, [document, isEdit]);

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -24,7 +24,6 @@ import Button from '@/components/Common/Button';
 import { usePutLaborContractEmployer } from '@/hooks/api/useDocument';
 import {
   handleHourlyRateBlur,
-  parseStringToSafeDecimalNumber,
   parseStringToSafeDecimalNumberText,
   parseStringToSafeNumber,
   validateLaborContractEmployerInformation,
@@ -61,7 +60,7 @@ const EmployerLaborContractForm = ({
   const [phoneNum, setPhoneNum] = useState({
     start: newDocumentData.phone_number
       ? parsePhoneNumber(newDocumentData.phone_number).start
-      : '',
+      : '010',
     middle: newDocumentData.phone_number
       ? parsePhoneNumber(newDocumentData.phone_number).middle
       : '',
@@ -157,7 +156,7 @@ const EmployerLaborContractForm = ({
         className={`w-full flex flex-col ${isPending ? 'overflow-hidden pointer-events-none' : ''}`}
       >
         {isAddressSearch ? (
-          <div className="w-full h-screen fixed inset-0 bg-white">
+          <div className="w-full h-screen fixed inset-0 bg-white z-[3]">
             <DaumPostcodeEmbed
               style={{
                 position: 'fixed',

--- a/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
@@ -70,11 +70,15 @@ const EmployerPartTimePermitForm = ({
     if (isEdit && document?.employer_information) {
       setNewDocumentData(document?.employer_information);
       setPhoneNum({
-        start: parsePhoneNumber(document?.employee_information.phone_number)
-          .start,
-        middle: parsePhoneNumber(document?.employee_information.phone_number)
-          .middle,
-        end: parsePhoneNumber(document?.employee_information.phone_number).end,
+        start: parsePhoneNumber(
+          document?.employer_information.phone_number as string,
+        ).start,
+        middle: parsePhoneNumber(
+          document?.employer_information.phone_number as string,
+        ).middle,
+        end: parsePhoneNumber(
+          document?.employer_information.phone_number as string,
+        ).end,
       });
     }
   }, [document, isEdit]);

--- a/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
@@ -52,7 +52,7 @@ const EmployerPartTimePermitForm = ({
   const [phoneNum, setPhoneNum] = useState({
     start: newDocumentData.phone_number
       ? parsePhoneNumber(newDocumentData.phone_number).start
-      : '',
+      : '010',
     middle: newDocumentData.phone_number
       ? parsePhoneNumber(newDocumentData.phone_number).middle
       : '',
@@ -130,7 +130,7 @@ const EmployerPartTimePermitForm = ({
         className={`w-full flex flex-col ${isPending ? 'overflow-hidden pointer-events-none' : ''}`}
       >
         {isAddressSearch ? (
-          <div className="w-full h-screen fixed inset-0 bg-white">
+          <div className="w-full h-screen fixed inset-0 bg-white z-[3]">
             <DaumPostcodeEmbed
               style={{
                 position: 'fixed',
@@ -139,6 +139,7 @@ const EmployerPartTimePermitForm = ({
                 height: 'calc(100vh - 100px)',
                 marginTop: '3.125rem',
                 paddingBottom: '6.25rem',
+                zIndex: 9999,
               }}
               theme={{ pageBgColor: '#ffffff', bgColor: '#ffffff' }}
               onComplete={handleAddressSelection}

--- a/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
@@ -33,6 +33,7 @@ import {
 import { phone } from '@/constants/information';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
+import { documentTranslation } from '@/constants/translation';
 
 type PartTimePermitFormProps = {
   document?: PartTimePermitData;
@@ -243,6 +244,12 @@ const EmployerPartTimePermitForm = ({
                       }
                       canDelete={false}
                     />
+                    {newDocumentData.address.address_detail &&
+                      newDocumentData.address.address_detail.length > 50 && (
+                        <p className="text-text-error text-xs p-2">
+                          {documentTranslation.detailAddressTooLong.ko}
+                        </p>
+                      )}
                   </InputLayout>
                 </>
               )}

--- a/src/components/Information/AddressStep.tsx
+++ b/src/components/Information/AddressStep.tsx
@@ -11,7 +11,10 @@ import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 import PageTitle from '../Common/PageTitle';
-import { signInputTranclation } from '@/constants/translation';
+import {
+  documentTranslation,
+  signInputTranclation,
+} from '@/constants/translation';
 import { useLocation } from 'react-router-dom';
 import { isEmployer } from '@/utils/signup';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
@@ -120,6 +123,12 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
                     }}
                     canDelete={false}
                   />
+                  {newAddress.address_detail &&
+                    newAddress.address_detail.length > 50 && (
+                      <p className="text-text-error text-xs p-2">
+                        {documentTranslation.detailAddressTooLong.en}
+                      </p>
+                    )}
                 </InputLayout>
               </>
             )}
@@ -132,13 +141,13 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
           type="large"
           bgColor={
             newAddress.address_detail &&
-            newAddress.address_detail?.trim().length > 100
+            newAddress.address_detail?.trim().length > 50
               ? 'bg-[#F4F4F9]'
               : 'bg-[#fef387]'
           }
           fontColor={
             newAddress.address_detail &&
-            newAddress.address_detail?.trim().length > 100
+            newAddress.address_detail?.trim().length > 50
               ? ''
               : 'text-[#222]'
           }
@@ -146,7 +155,7 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
           title="Next"
           onClick={
             newAddress.address_detail &&
-            newAddress.address_detail?.trim().length > 100
+            newAddress.address_detail?.trim().length > 50
               ? undefined
               : () =>
                   onNext({

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -36,6 +36,7 @@ import {
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import InputLayout from '../WorkExperience/InputLayout';
+import { documentTranslation } from '@/constants/translation';
 
 type IntegratedApplicationFormProps = {
   document?: IntegratedApplicationData;
@@ -291,8 +292,6 @@ const IntegratedApplicationWriteForm = ({
                       placeholder="ex) 101-dong"
                       value={newDocumentData.address.address_detail}
                       onChange={(value) =>
-                        value &&
-                        value.trim().length < 100 &&
                         setNewDocumentData({
                           ...newDocumentData,
                           address: {
@@ -303,6 +302,12 @@ const IntegratedApplicationWriteForm = ({
                       }
                       canDelete={false}
                     />
+                    {newDocumentData.address.address_detail &&
+                      newDocumentData.address.address_detail.length > 50 && (
+                        <p className="text-text-error text-xs p-2">
+                          {documentTranslation.detailAddressTooLong.en}
+                        </p>
+                      )}
                   </InputLayout>
                 </>
               )}

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -33,6 +33,7 @@ import { useCurrentPostIdEmployeeStore } from '@/store/url';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import InputLayout from '../WorkExperience/InputLayout';
+import { documentTranslation } from '@/constants/translation';
 
 type IntegratedApplicationFormProps = {
   document?: IntegratedApplicationData;
@@ -287,8 +288,6 @@ const IntegratedApplicationWriteForm = ({
                       placeholder="ex) 101-dong"
                       value={newDocumentData.address.address_detail}
                       onChange={(value) =>
-                        value &&
-                        value.trim().length < 100 &&
                         setNewDocumentData({
                           ...newDocumentData,
                           address: {
@@ -299,6 +298,12 @@ const IntegratedApplicationWriteForm = ({
                       }
                       canDelete={false}
                     />
+                    {newDocumentData.address.address_detail &&
+                      newDocumentData.address.address_detail.length > 50 && (
+                        <p className="text-text-error text-xs p-2">
+                          {documentTranslation.detailAddressTooLong.en}
+                        </p>
+                      )}
                   </InputLayout>
                 </>
               )}

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -59,9 +59,11 @@ const LaborContractWriteForm = ({
         signature_base64: document.employee_information.signature_base64,
       });
       setPhoneNum({
-        start: parsePhoneNumber(newDocumentData.phone_number).start,
-        middle: parsePhoneNumber(newDocumentData.phone_number).middle,
-        end: parsePhoneNumber(newDocumentData.phone_number).end,
+        start: parsePhoneNumber(document.employee_information.phone_number)
+          .start,
+        middle: parsePhoneNumber(document.employee_information.phone_number)
+          .middle,
+        end: parsePhoneNumber(document.employee_information.phone_number).end,
       });
     }
   }, [document, isEdit]);

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -24,6 +24,7 @@ import { useCurrentDocumentIdStore, useCurrentPostIdEmployeeStore } from '@/stor
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import InputLayout from '../WorkExperience/InputLayout';
+import { documentTranslation } from '@/constants/translation';
 
 type LaborContractFormProps = {
   document?: LaborContractDataResponse;
@@ -193,8 +194,6 @@ const LaborContractWriteForm = ({
                       placeholder="ex) 101-dong"
                       value={newDocumentData.address.address_detail}
                       onChange={(value) =>
-                        value &&
-                        value.trim().length < 100 &&
                         setNewDocumentData({
                           ...newDocumentData,
                           address: {
@@ -205,6 +204,12 @@ const LaborContractWriteForm = ({
                       }
                       canDelete={false}
                     />
+                    {newDocumentData.address.address_detail &&
+                      newDocumentData.address.address_detail.length > 50 && (
+                        <p className="text-text-error text-xs p-2">
+                          {documentTranslation.detailAddressTooLong.en}
+                        </p>
+                      )}
                   </InputLayout>
                 </>
               )}

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -24,6 +24,7 @@ import { useCurrentPostIdEmployeeStore } from '@/store/url';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import InputLayout from '../WorkExperience/InputLayout';
+import { documentTranslation } from '@/constants/translation';
 
 type LaborContractFormProps = {
   document?: LaborContractDataResponse;
@@ -192,8 +193,6 @@ const LaborContractWriteForm = ({
                       placeholder="ex) 101-dong"
                       value={newDocumentData.address.address_detail}
                       onChange={(value) =>
-                        value &&
-                        value.trim().length < 100 &&
                         setNewDocumentData({
                           ...newDocumentData,
                           address: {
@@ -204,6 +203,12 @@ const LaborContractWriteForm = ({
                       }
                       canDelete={false}
                     />
+                    {newDocumentData.address.address_detail &&
+                      newDocumentData.address.address_detail.length > 50 && (
+                        <p className="text-text-error text-xs p-2">
+                          {documentTranslation.detailAddressTooLong.en}
+                        </p>
+                      )}
                   </InputLayout>
                 </>
               )}

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -60,9 +60,11 @@ const LaborContractWriteForm = ({
         signature_base64: document.employee_information.signature_base64,
       });
       setPhoneNum({
-        start: parsePhoneNumber(newDocumentData.phone_number).start,
-        middle: parsePhoneNumber(newDocumentData.phone_number).middle,
-        end: parsePhoneNumber(newDocumentData.phone_number).end,
+        start: parsePhoneNumber(document.employee_information.phone_number)
+          .start,
+        middle: parsePhoneNumber(document.employee_information.phone_number)
+          .middle,
+        end: parsePhoneNumber(document.employee_information.phone_number).end,
       });
     }
   }, [document, isEdit]);

--- a/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
+++ b/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
@@ -170,6 +170,17 @@ const PartTimePermitWriteForm = ({
               }}
               canDelete={false}
             />
+            <Dropdown
+              value={String(newDocumentData.term_of_completion)}
+              placeholder="Term of completion"
+              options={Array.from({ length: 12 }, (_, i) => String(i + 1))}
+              setValue={(value) =>
+                setNewDocumentData({
+                  ...newDocumentData,
+                  term_of_completion: Number(value),
+                })
+              }
+            />
           </InputLayout>
           {/* 이메일 입력 */}
           <InputLayout title="Email" isEssential>

--- a/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
+++ b/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
@@ -59,9 +59,11 @@ const PartTimePermitWriteForm = ({
         email: document.employee_information.email,
       });
       setPhoneNum({
-        start: parsePhoneNumber(newDocumentData.phone_number).start,
-        middle: parsePhoneNumber(newDocumentData.phone_number).middle,
-        end: parsePhoneNumber(newDocumentData.phone_number).end,
+        start: parsePhoneNumber(document.employee_information.phone_number)
+          .start,
+        middle: parsePhoneNumber(document.employee_information.phone_number)
+          .middle,
+        end: parsePhoneNumber(document.employee_information.phone_number).end,
       });
     }
   }, [document, isEdit]);

--- a/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
+++ b/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
@@ -174,6 +174,17 @@ const PartTimePermitWriteForm = ({
               }}
               canDelete={false}
             />
+            <Dropdown
+              value={String(newDocumentData.term_of_completion)}
+              placeholder="Term of completion"
+              options={Array.from({ length: 12 }, (_, i) => String(i + 1))}
+              setValue={(value) =>
+                setNewDocumentData({
+                  ...newDocumentData,
+                  term_of_completion: Number(value),
+                })
+              }
+            />
           </InputLayout>
           {/* 이메일 입력 */}
           <InputLayout title="Email" isEssential>

--- a/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
+++ b/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
@@ -55,9 +55,11 @@ const PartTimePermitWriteForm = ({
         email: document.employee_information.email,
       });
       setPhoneNum({
-        start: parsePhoneNumber(newDocumentData.phone_number).start,
-        middle: parsePhoneNumber(newDocumentData.phone_number).middle,
-        end: parsePhoneNumber(newDocumentData.phone_number).end,
+        start: parsePhoneNumber(document.employee_information.phone_number)
+          .start,
+        middle: parsePhoneNumber(document.employee_information.phone_number)
+          .middle,
+        end: parsePhoneNumber(document.employee_information.phone_number).end,
       });
     }
   }, [document, isEdit]);

--- a/src/constants/translation.ts
+++ b/src/constants/translation.ts
@@ -569,3 +569,10 @@ export const bannerTranslation = {
     en: 'Giggle will be back with some useful information soon!',
   },
 };
+
+export const documentTranslation = {
+  detailAddressTooLong: {
+    ko: '상세주소는 50자 이내로 입력해주세요',
+    en: 'max 50 characters.',
+  },
+};

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -25,6 +25,7 @@ import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
+import { documentTranslation } from '@/constants/translation';
 
 const EditProfilePage = () => {
   const { data: userProfile } = useGetUserProfile();
@@ -276,8 +277,6 @@ const EditProfilePage = () => {
                         placeholder="ex) 101dong"
                         value={userData.address.address_detail}
                         onChange={(value) =>
-                          value &&
-                          value.trim().length < 100 &&
                           setUserData({
                             ...userData,
                             address: {
@@ -288,6 +287,12 @@ const EditProfilePage = () => {
                         }
                         canDelete={false}
                       />
+                      {userData.address.address_detail &&
+                        userData.address.address_detail.length > 50 && (
+                          <p className="text-text-error text-xs p-2">
+                            {documentTranslation.detailAddressTooLong.en}
+                          </p>
+                        )}
                     </InputLayout>
                   </>
                 )}

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -118,7 +118,8 @@ export const validateEmployerInformation = (
     !info.company_name ||
     !info.job_type ||
     !info.name ||
-    !info.phone_number
+    !info.phone_number ||
+    !info.signature_base64
   ) {
     return false;
   }

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -291,7 +291,7 @@ export const validateIntegratedApplication = (
   // 주소 검사
   const isAddressValid =
     data.address.region_1depth_name !== '' &&
-    data.address.address_detail &&
+    !!data.address.address_detail &&
     data.address.address_detail.length <= 50;
 
   // annual_income_amount 검사

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -224,6 +224,20 @@ export const parseStringToSafeNumber = (value: string): number => {
   else return numberValue;
 };
 
+export const parseStringToSafeDecimalNumberText = (value: string): string => {
+  // 숫자와 소수점만 허용하는 정규식 검사
+  if (value === '' || /^[0-9]*\.?[0-9]*$/.test(value)) {
+    return value;
+  }
+
+  // 유효하지 않은 입력이면 이전 유효한 값 반환
+  const cleanedValue = value.replace(/[^0-9.]/g, '');
+
+  // 소수점이 여러 개 있으면 첫 번째만 유지
+  const parts = cleanedValue.split('.');
+  return parts[0] + (parts.length > 1 ? '.' + parts[1] : '');
+};
+
 // 시급 필드 onBlur 이벤트 핸들러
 export const handleHourlyRateBlur = (value: string) => {
   const parsedValue = parseStringToSafeNumber(value);

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -27,6 +27,9 @@ export const isNotEmpty = (obj: Record<string, any>): boolean => {
       return value.trim().length > 0;
     }
 
+    if (key !== 'address') {
+      return value.address_detail.length <= 50;
+    }
     // 숫자나 불리언 등 다른 타입은 true 반환
     return true;
   });
@@ -146,7 +149,11 @@ export const validateEmployerInformation = (
   }
 
   // 주소 체크
-  if (!info.address?.region_1depth_name || !info.address.address_detail) {
+  if (
+    !info.address?.region_1depth_name ||
+    !info.address.address_detail ||
+    info.address.address_detail.length > 50
+  ) {
     return false;
   }
 
@@ -210,7 +217,11 @@ export const validateLaborContractEmployerInformation = (
   }
 
   // 주소 체크
-  if (!info.address?.region_1depth_name || !info.address.address_detail) {
+  if (
+    !info.address?.region_1depth_name ||
+    !info.address.address_detail ||
+    info.address.address_detail.length > 50
+  ) {
     return false;
   }
 
@@ -278,7 +289,10 @@ export const validateIntegratedApplication = (
   data: IntegratedApplicationData,
 ): boolean => {
   // 주소 검사
-  const isAddressValid = data.address.region_1depth_name !== '';
+  const isAddressValid =
+    data.address.region_1depth_name !== '' &&
+    data.address.address_detail &&
+    data.address.address_detail.length <= 50;
 
   // annual_income_amount 검사
   const isIncomeValid = data.annual_income_amount !== 0;

--- a/src/utils/editProfileData.ts
+++ b/src/utils/editProfileData.ts
@@ -116,6 +116,15 @@ export const validateFieldValues = (
         return true;
       case 'phone_number':
         return isValidPhoneNumber(phoneNum);
+      case 'address':
+        // 주소는 필수 입력이 아니므로 체크하지 않으나, 만약 입력되어 있다면 detail이 50자 이하인지 확인
+        if (value) {
+          const address = value as {
+            address_detail: string;
+          };
+          return address.address_detail.length <= 50;
+        }
+        return true;
     }
     return true;
   });

--- a/src/utils/map.tsx
+++ b/src/utils/map.tsx
@@ -31,7 +31,7 @@ export const renderMap = (address: GiggleAddress) => {
           {address.address_name} {address.address_detail}
         </div>
       </div>
-      <div className="w-full rounded-lg">
+      <div className="w-full rounded-lg z-1">
         <Map
           center={{
             lat: Number(address.latitude),

--- a/src/utils/map.tsx
+++ b/src/utils/map.tsx
@@ -27,8 +27,9 @@ export const renderMap = (address: GiggleAddress) => {
   return (
     <>
       <div className="w-full self-stretch flex flex-col items-start justify-start">
-        <div className="w-full flex-1 relative body-2">
-          {address.address_name} {address.address_detail}
+        <div className="w-full flex-1 relative body-2 mb-1">
+          {address.address_name}
+          {', '} {address.address_detail}
         </div>
       </div>
       <div className="w-full rounded-lg z-1">

--- a/src/utils/signup.ts
+++ b/src/utils/signup.ts
@@ -34,7 +34,8 @@ export const isValidEmployerRegistration = (
     !address.region_3depth_name ||
     !isValidString(address.region_3depth_name) ||
     !address.address_detail ||
-    !isValidString(address.address_detail)
+    !isValidString(address.address_detail) ||
+    !(address.address_detail.length <= 50)
   ) {
     return false;
   }


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #280 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 고용주 문서 수정 시 고용주 전화번호 올바르게 매핑
- 시간제 취업 허가서 작성 시 유효성 검사 변경
- 초과근로에 대한 가산임금률 소수 입력 가능하도록 수정
- 다음주소검색 API 위로 카카오맵이 올라오는 에러 해결
- 상세 주소 50자 이하로 유효성 검사 & 안내 문구 출력
- 이수학기 입력 시 모달 선택형으로 변경
- 문서 미리보기에서 이메일 첫 글자 대문자로 출력되는 현상 수정
- 서류 미리보기 내 주소, 상세 주소 스타일 조정


https://github.com/user-attachments/assets/6f4b5007-f513-4657-88f2-c0a656795b03

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Task1

## To Reviewers 📢

어쨰서 커밋이 2배로 뻥튀기 되었는지는 모르겠으나.. 일단 괜찮은 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 상세 주소 입력이 50자를 초과할 경우, 여러 양식에서 사용자에게 경고 메시지가 표시되어 입력 오류를 빠르게 인지할 수 있습니다.
	- 작성 양식에 완료 기간 선택 드롭다운이 추가되어 보다 편리하게 옵션을 선택할 수 있습니다.
	- 이메일이 유효하지 않을 경우 "none"으로 표시되는 등 정보 표시 방식이 개선되었습니다.

- **Bug Fixes**
	- 전화번호 입력이 올바른 고정값("010")과 올바른 정보 출처를 사용하도록 수정되어, 데이터 입력의 정확성이 향상되었습니다.
	- 급여 입력의 유효성 검사 및 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->