### PR TITLE
[Fix/285] 서류 신청 관리 오류 수정 및 급한 QA 반영하기

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.11.1",
+    "@eslint/js": "^9.12.0",
     "@types/node": "^22.7.5",
-    "@types/react": "^18.3.10",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
@@ -45,14 +45,14 @@
     "eslint-plugin-react-hooks": "5.1.0-rc-fb9a90fa48-20240614",
     "eslint-plugin-react-refresh": "^0.4.12",
     "eslint-plugin-tailwindcss": "^3.17.5",
-    "globals": "^15.9.0",
+    "globals": "^15.11.0",
     "postcss": "^8.4.47",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.14",
     "ts-prune": "^0.10.3",
-    "typescript": "^5.5.3",
-    "typescript-eslint": "^8.7.0",
-    "vite": "^5.4.8",
+    "typescript": "^5.6.3",
+    "typescript-eslint": "^8.9.0",
+    "vite": "^5.4.9",
     "vite-plugin-svgr": "^4.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,16 +61,16 @@ importers:
         version: 5.0.0(@types/react@18.3.11)(react@18.3.1)
     devDependencies:
       '@eslint/js':
-        specifier: ^9.11.1
+        specifier: ^9.12.0
         version: 9.12.0
       '@types/node':
         specifier: ^22.7.5
         version: 22.7.5
       '@types/react':
-        specifier: ^18.3.10
+        specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
+        specifier: ^18.3.1
         version: 18.3.1
       '@types/react-router-dom':
         specifier: ^5.3.3
@@ -106,7 +106,7 @@ importers:
         specifier: ^3.17.5
         version: 3.17.5(tailwindcss@3.4.14)
       globals:
-        specifier: ^15.9.0
+        specifier: ^15.11.0
         version: 15.11.0
       postcss:
         specifier: ^8.4.47
@@ -121,13 +121,13 @@ importers:
         specifier: ^0.10.3
         version: 0.10.3
       typescript:
-        specifier: ^5.5.3
+        specifier: ^5.6.3
         version: 5.6.3
       typescript-eslint:
-        specifier: ^8.7.0
+        specifier: ^8.9.0
         version: 8.9.0(eslint@9.12.0(jiti@1.21.6))(typescript@5.6.3)
       vite:
-        specifier: ^5.4.8
+        specifier: ^5.4.9
         version: 5.4.9(@types/node@22.7.5)
       vite-plugin-svgr:
         specifier: ^4.2.0
@@ -899,8 +899,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001669:
-    resolution: {integrity: sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==}
+  caniuse-lite@1.0.30001707:
+    resolution: {integrity: sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -3049,7 +3049,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.4.47):
     dependencies:
       browserslist: 4.24.0
-      caniuse-lite: 1.0.30001669
+      caniuse-lite: 1.0.30001707
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.0
@@ -3091,7 +3091,7 @@ snapshots:
 
   browserslist@4.24.0:
     dependencies:
-      caniuse-lite: 1.0.30001669
+      caniuse-lite: 1.0.30001707
       electron-to-chromium: 1.5.39
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.0)
@@ -3110,7 +3110,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001669: {}
+  caniuse-lite@1.0.30001707: {}
 
   chalk@2.4.2:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,16 +10,23 @@ import { useState } from 'react';
 import ServerErrorBottomSheet from '@/components/Common/ServerErrorBottomSheet';
 import { LoadingOverLay } from '@/components/Common/LoadingItem';
 import { ReactNativeMessageListener } from '@/components/Common/ReactNativeMessageListener';
+import ApiErrorBottomSheet from './components/Common/ApiErrorBottomSheet';
 
 function App() {
+  const [isOpenServerErrorBottomSheet, setIsOpenServerErrorBottomSheet] =
+    useState(false);
   const [isOpenErrorBottomSheet, setIsOpenErrorBottomSheet] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
 
   const openErrorBottomSheet = (error: unknown) => {
     if (!axios.isAxiosError(error)) return;
 
     if (error.response?.status === 500 || error.response?.status === 408) {
+      setIsOpenServerErrorBottomSheet(true);
+    } else if (error.response?.status !== 401) {
       setIsOpenErrorBottomSheet(true);
+      setErrorMessage(error.response?.data?.error?.message ?? '');
     }
   };
 
@@ -47,8 +54,15 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ReactNativeMessageListener />
       <Router />
-      {isOpenErrorBottomSheet && (
+      {isOpenServerErrorBottomSheet && (
         <ServerErrorBottomSheet
+          isShowBottomsheet={isOpenServerErrorBottomSheet}
+          setIsShowBottomSheet={setIsOpenServerErrorBottomSheet}
+        />
+      )}
+      {isOpenErrorBottomSheet && (
+        <ApiErrorBottomSheet
+          errorMessage={errorMessage}
           isShowBottomsheet={isOpenErrorBottomSheet}
           setIsShowBottomSheet={setIsOpenErrorBottomSheet}
         />

--- a/src/components/ApplicationDetail/ApplicationDetailStep4.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep4.tsx
@@ -23,7 +23,13 @@ const ApplicationDetailStep4 = () => {
           fontColor="text-surface-invert"
           isBorder={false}
           title="Check the application documents"
-          onClick={() => navigate(`/application-documents/${id}`)}
+          onClick={() =>
+            navigate(`/application-documents/${id}`, {
+              state: {
+                isComplete: true,
+              },
+            })
+          }
         />
       </section>
     </>

--- a/src/components/ApplicationDetail/ApplicationDetailStep5.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep5.tsx
@@ -27,7 +27,13 @@ const ApplicationDetailStep5 = () => {
           fontColor="text-surface-invert"
           isBorder={false}
           title="Check the application documents"
-          onClick={() => navigate(`/application-documents/${id}`)}
+          onClick={() =>
+            navigate(`/application-documents/${id}`, {
+              state: {
+                isComplete: true,
+              },
+            })
+          }
         />
       </section>
       <ContactHikoreaBottomSheet

--- a/src/components/ApplicationDetail/ApplicationDetailStep6.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep6.tsx
@@ -22,7 +22,13 @@ const ApplicationDetailStep6 = () => {
         fontColor="text-surface-invert"
         isBorder={false}
         title="Check the application documents"
-        onClick={() => navigate(`/application-documents/${id}`)}
+        onClick={() =>
+          navigate(`/application-documents/${id}`, {
+            state: {
+              isComplete: true,
+            },
+          })
+        }
       />
     </section>
   );

--- a/src/components/ApplicationDetail/ApplicationDetailStep7.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep7.tsx
@@ -37,7 +37,13 @@ const ApplicationDetailStep7 = ({ result }: ApplicationDetailStep7Props) => {
         fontColor="text-surface-invert"
         isBorder={false}
         title="Check the application documents"
-        onClick={() => navigate(`/application-documents/${id}`)}
+        onClick={() =>
+          navigate(`/application-documents/${id}`, {
+            state: {
+              isComplete: true,
+            },
+          })
+        }
       />
     </section>
   );

--- a/src/components/Common/ApiErrorBottomSheet.tsx
+++ b/src/components/Common/ApiErrorBottomSheet.tsx
@@ -1,0 +1,47 @@
+import BottomSheetLayout from '@/components/Common/BottomSheetLayout';
+import Button from '@/components/Common/Button';
+import { buttonTypeKeys } from '@/constants/components';
+
+type ApiErrorBottomSheetPropsType = {
+  errorMessage: string;
+  isShowBottomsheet: boolean;
+  setIsShowBottomSheet: (isShowBottomsheet: boolean) => void;
+};
+
+const ApiErrorBottomSheet = ({
+  errorMessage,
+  isShowBottomsheet,
+  setIsShowBottomSheet,
+}: ApiErrorBottomSheetPropsType) => {
+  const handleClickBackButton = () => {
+    if (window.history.length > 1) window.history.back();
+    else window.location.href = '/';
+
+    setIsShowBottomSheet(false);
+  };
+
+  return (
+    <BottomSheetLayout
+      hasHandlebar={false}
+      isAvailableHidden={false}
+      isShowBottomsheet={isShowBottomsheet}
+    >
+      <div className="w-full pt-2 px-2 pb-6 flex flex-col gap-6 items-center text-center">
+        <h3 className="head-3 text-text-normal">문제가 발생했어요 ! 😢</h3>
+        <p className="body-2 text-text-normal">{errorMessage}</p>
+      </div>
+      <div className="w-full pt-3">
+        <Button
+          type={buttonTypeKeys.LARGE}
+          bgColor="bg-surface-primary"
+          fontColor="text-text-normal"
+          isBorder={false}
+          title={'뒤로가기'}
+          onClick={handleClickBackButton}
+        />
+      </div>
+    </BottomSheetLayout>
+  );
+};
+
+export default ApiErrorBottomSheet;

--- a/src/components/Common/Input.tsx
+++ b/src/components/Common/Input.tsx
@@ -24,6 +24,7 @@ type InputProps = {
   isInvalid?: boolean; // 유효하지 않은 입력 상태 여부 (선택적)
   onDelete?: () => void; // 삭제 버튼 클릭 시 호출될 함수 (선택적)
   isPrefix?: boolean; // 접두사 여부
+  isPreventFocus?: boolean; // input focus 막을지 여부
   prefix?: string; // 접두사 내용
   isUnit?: boolean; // 단위 여부
   unit?: string; // 단위 내용
@@ -53,6 +54,7 @@ const Input = ({
   isInvalid,
   value,
   isPrefix,
+  isPreventFocus,
   prefix,
   isUnit,
   unit,
@@ -114,6 +116,7 @@ const Input = ({
               : 'password'
             : 'text'
         }
+        onFocus={(e) => isPreventFocus && e.target.blur()}
       />
       {/* 비밀번호 타입일 경우 표시/숨김 토글 아이콘을 표시합니다. */}
       {/* TODO : 추후 아이콘 추가 되면 비밀번호 가시 여부에 따라서 다른 아이콘 적용*/}

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -413,6 +413,7 @@ const IntegratedApplicationWriteForm = ({
                   value={newDocumentData.school_name}
                   onChange={() => {}}
                   canDelete={false}
+                  isPreventFocus={true}
                 />
               </div>
             </InputLayout>

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -20,7 +20,10 @@ import {
   usePostStandardLaborContracts,
   usePutStandardLaborContracts,
 } from '@/hooks/api/useDocument';
-import { useCurrentDocumentIdStore, useCurrentPostIdEmployeeStore } from '@/store/url';
+import {
+  useCurrentDocumentIdStore,
+  useCurrentPostIdEmployeeStore,
+} from '@/store/url';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import InputLayout from '../WorkExperience/InputLayout';
@@ -169,7 +172,7 @@ const LaborContractWriteForm = ({
                 </div>
               </InputLayout>
               {/* 검색한 위치를 보여주는 지도 */}
-              {newDocumentData.address.address_detail !== '' && (
+              {newDocumentData.address.address_name !== '' && (
                 <>
                   <div className="w-full rounded-xl">
                     <Map

--- a/src/constants/translation.ts
+++ b/src/constants/translation.ts
@@ -108,7 +108,7 @@ export const signInputTranclation = {
     en: 'Enter the code from the email we sent you',
   },
   resetPasswordVerifySuccess: {
-    ko: '인증이 완료되었어요!',
+    ko: '인증',
   },
   verifyFailed: {
     ko: '인증에 실패했습니다. 인증번호 재발급 후 다시 시도해주세요. ',

--- a/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
+++ b/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
@@ -10,7 +10,7 @@ import { useGetDocumentsEmployee } from '@/hooks/api/useDocument';
 import { useCurrentPostIdEmployeeStore } from '@/store/url';
 import { DocumentsSummaryResponse } from '@/types/api/document';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export type SuccessModalContent = {
   title: string;
@@ -19,6 +19,9 @@ export type SuccessModalContent = {
 };
 
 const ApplicationDocumentsPage = () => {
+  const location = useLocation();
+  const { isComplete } = location.state || {};
+
   const navigate = useNavigate();
   const { currentPostId } = useCurrentPostIdEmployeeStore();
   const { data, isPending } = useGetDocumentsEmployee(Number(currentPostId));
@@ -57,8 +60,8 @@ const ApplicationDocumentsPage = () => {
           />
           <section className="w-full bg-surface-secondary">
             <PageTitle
-              title={`Your Resume,\nYour Next Opportunity 🚀`}
-              content={`Keep your resume updated and\ntrack your job applications in one place!`}
+              title={`All your work documents,\nin one place!🚀`}
+              content={`Easily track and manage your docs! Stay on\ntop of the process and complete the required\n steps smoothly.`}
             />
             {isPending ? (
               <div className="w-full h-[65vh] flex items-center justify-center">
@@ -72,26 +75,28 @@ const ApplicationDocumentsPage = () => {
                     setSuccessModalContent(content)
                   }
                 />
-                <BottomButtonPanel>
-                  <Button
-                    type="large"
-                    bgColor={
-                      isDocumentComplete(data?.data)
-                        ? 'bg-surface-primary'
-                        : 'bg-surface-secondary'
-                    }
-                    fontColor={
-                      isDocumentComplete(data?.data)
-                        ? 'text-text-normal'
-                        : 'text-text-disabled'
-                    }
-                    title="Next"
-                    isBorder={false}
-                    {...(isDocumentComplete(data?.data) && {
-                      onClick: () => submitDocuments(Number(currentPostId)),
-                    })}
-                  />
-                </BottomButtonPanel>
+                {!isComplete && (
+                  <BottomButtonPanel>
+                    <Button
+                      type="large"
+                      bgColor={
+                        isDocumentComplete(data?.data)
+                          ? 'bg-surface-primary'
+                          : 'bg-surface-secondary'
+                      }
+                      fontColor={
+                        isDocumentComplete(data?.data)
+                          ? 'text-text-normal'
+                          : 'text-text-disabled'
+                      }
+                      title="Completed"
+                      isBorder={false}
+                      {...(isDocumentComplete(data?.data) && {
+                        onClick: () => submitDocuments(Number(currentPostId)),
+                      })}
+                    />
+                  </BottomButtonPanel>
+                )}
               </>
             )}
           </section>

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -24,11 +24,11 @@ export const isNotEmpty = (obj: Record<string, any>): boolean => {
 
     // 문자열이면서 phone_number가 아닌 경우 trim()으로 공백 제거 후 길이 확인
     if (typeof value === 'string' && key !== 'phone_number') {
-      return value.trim().length > 0;
+      return value.trim()?.length > 0;
     }
 
-    if (key !== 'address') {
-      return value.address_detail.length <= 50;
+    if (key === 'address') {
+      return value.address_detail?.length <= 50;
     }
     // 숫자나 불리언 등 다른 타입은 true 반환
     return true;

--- a/src/utils/map.tsx
+++ b/src/utils/map.tsx
@@ -54,22 +54,14 @@ export const renderMap = (address: GiggleAddress) => {
 };
 
 export const convertToAddress = (addressData: Address): GiggleAddress => {
-  // 주소 타입에 따라 기본 주소 선택
-  const baseAddress =
-    addressData.userSelectedType === 'R'
-      ? addressData.roadAddress
-      : addressData.jibunAddress;
-  // region_3depth_name 추출
-  const region3DepthName = baseAddress
-    .replace(addressData.sido, '')
-    .replace(addressData.sigungu, '')
-    .trim();
+  // 무조건 지번 주소 사용하기
+  const baseAddress = addressData.jibunAddress;
 
   return {
     address_name: baseAddress,
     region_1depth_name: addressData.sido,
     region_2depth_name: addressData.sigungu,
-    region_3depth_name: region3DepthName,
+    region_3depth_name: addressData.bname,
     region_4depth_name: null,
     address_detail: null,
     longitude: null,


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #285

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 유학생 신청 Step 4 이후부터 신청 서류 관리 페이지에서 complete 버튼 없애고 문구 변경하기
- 500, 401을 제외한 서버 에러 발생 시 Bottomsheet로 안내하기 
- 주소 검색 시에 무조건 지번 주소 사용하고 region_3depth_name에 bname값 저장하기
- 유학생 근로 계약서 작성 오류 수정하기 
- 통합지원신청서 작성 시 bottomSheet가 열린 후에도 이전 input에 focus 남아있는 문제 
- 임시 비밀번호 발급 페이지에서 "인증이 완료되었어요!" > 인증" 텍스트 변경

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"


## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

급한 내용이라 우선은 머지하겠습니다 ㅠㅠ!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 서버와 API 에러를 구분하여 전용 알림창을 통해 명확한 에러 메시지를 제공하도록 개선했습니다.
  - 지원서 문서 페이지로 이동 시 완료 상태가 반영되어 보다 직관적인 네비게이션이 구현되었습니다.
  - 폼 입력 시 불필요한 포커스를 방지하는 기능과 주소 입력에 따른 지도 표시 로직이 개선되었습니다.
  - 비밀번호 인증 성공 메시지와 페이지 제목 등 UI 문구를 간결하게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->