### PR TITLE
[Fix/288] - 비밀번호 변경 페이지 로직 변경

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,6 +2,7 @@ import {
   AuthenticationRequest,
   AuthenticationResponse,
   ChangePasswordRequest,
+  CurrentPasswordRequest,
   PolicyResponse,
   ReIssueAuthenticationRequest,
   SignInRequest,
@@ -176,6 +177,14 @@ export const patchPassword = async (
   passwords: ChangePasswordRequest,
 ): Promise<RESTYPE<null>> => {
   const response = await api.patch('/auth/password', passwords);
+  return response.data;
+};
+
+// 2.12 현재 비밀번호 확인
+export const postValidatePassword = async (
+  password: CurrentPasswordRequest,
+): Promise<RESTYPE<ValidationResponse>> => {
+  const response = await api.post('/auth/validations/password', password);
   return response.data;
 };
 

--- a/src/components/Profile/Password/CurrentPasswordStep.tsx
+++ b/src/components/Profile/Password/CurrentPasswordStep.tsx
@@ -11,12 +11,14 @@ import Input from '@/components/Common/Input';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import { InputType } from '@/types/common/input';
+import { isEmployerByAccountType } from '@/utils/signup';
 
 interface CurrentPasswordStepProps {
   password: string;
   onPasswordChange: (value: string) => void;
   onSubmit: () => void;
   error: string | null;
+  isValid: boolean;
 }
 
 const CurrentPasswordStep = ({
@@ -24,9 +26,9 @@ const CurrentPasswordStep = ({
   onPasswordChange,
   onSubmit,
   error,
+  isValid,
 }: CurrentPasswordStepProps) => {
   const { account_type } = useUserStore();
-  const userLanguage = account_type === UserType.USER ? 'en' : 'ko';
   const navigate = useNavigate();
 
   return (
@@ -42,16 +44,28 @@ const CurrentPasswordStep = ({
       <div className="w-full h-full min-h-[100vh] px-4 ">
         <div className="title-1 break-keep my-[3.125rem] w-full">
           <p className="h-20">
-            {profileTranslation.enterYourPassword[userLanguage]}
+            {
+              profileTranslation.enterYourPassword[
+                isEmployerByAccountType(account_type)
+              ]
+            }
           </p>
         </div>
         <InputLayout
           isEssential
-          title={profileTranslation.currentPassword[userLanguage]}
+          title={
+            profileTranslation.currentPassword[
+              isEmployerByAccountType(account_type)
+            ]
+          }
         >
           <Input
             inputType={InputType.PASSWORD}
-            placeholder={profileTranslation.enterCurrentPassword[userLanguage]}
+            placeholder={
+              profileTranslation.enterCurrentPassword[
+                isEmployerByAccountType(account_type)
+              ]
+            }
             value={password}
             onChange={onPasswordChange}
             canDelete={false}
@@ -65,15 +79,15 @@ const CurrentPasswordStep = ({
           <div className="w-full">
             <Button
               type="large"
-              bgColor={
-                password !== '' ? 'bg-surface-primary' : 'bg-surface-secondary'
-              }
-              fontColor={
-                password !== '' ? 'text-text-normal' : 'text-text-disabled'
-              }
+              bgColor={isValid ? 'bg-surface-primary' : 'bg-surface-secondary'}
+              fontColor={isValid ? 'text-text-normal' : 'text-text-disabled'}
               isBorder={false}
-              title={signInputTranclation.continue[userLanguage]}
-              onClick={password !== '' ? onSubmit : undefined}
+              title={
+                signInputTranclation.continue[
+                  isEmployerByAccountType(account_type)
+                ]
+              }
+              onClick={isValid ? onSubmit : undefined}
             />
           </div>
         </BottomButtonPanel>

--- a/src/components/Profile/Password/NewPasswordStep.tsx
+++ b/src/components/Profile/Password/NewPasswordStep.tsx
@@ -11,6 +11,7 @@ import Input from '@/components/Common/Input';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import { InputType } from '@/types/common/input';
+import { isEmployerByAccountType } from '@/utils/signup';
 
 interface NewPasswordStepProps {
   newPassword: string;
@@ -36,9 +37,8 @@ const NewPasswordStep = ({
   isValid,
 }: NewPasswordStepProps) => {
   const { account_type } = useUserStore();
-  const userLanguage = account_type === UserType.USER ? 'en' : 'ko';
   const navigate = useNavigate();
-  // password 유효성 검사
+
   return (
     <>
       <BaseHeader
@@ -52,17 +52,29 @@ const NewPasswordStep = ({
       <div className="w-full h-full min-h-[100vh] px-4 ">
         <div className="title-1 break-keep my-[3.125rem] w-full">
           <p className="h-20">
-            {profileTranslation.enterYourPassword[userLanguage]}
+            {
+              profileTranslation.enterYourPassword[
+                isEmployerByAccountType(account_type)
+              ]
+            }
           </p>
         </div>
         <div className="flex flex-col gap-4">
           <InputLayout
             isEssential
-            title={profileTranslation.newPassword[userLanguage]}
+            title={
+              profileTranslation.newPassword[
+                isEmployerByAccountType(account_type)
+              ]
+            }
           >
             <Input
               inputType={InputType.PASSWORD}
-              placeholder={profileTranslation.enterNewPassword[userLanguage]}
+              placeholder={
+                profileTranslation.enterNewPassword[
+                  isEmployerByAccountType(account_type)
+                ]
+              }
               value={newPassword}
               onChange={onNewPasswordChange}
               canDelete={false}
@@ -73,12 +85,18 @@ const NewPasswordStep = ({
           </InputLayout>
           <InputLayout
             isEssential
-            title={profileTranslation.confirmPassword[userLanguage]}
+            title={
+              profileTranslation.confirmPassword[
+                isEmployerByAccountType(account_type)
+              ]
+            }
           >
             <Input
               inputType={InputType.PASSWORD}
               placeholder={
-                profileTranslation.enterConfirmPassword[userLanguage]
+                profileTranslation.enterConfirmPassword[
+                  isEmployerByAccountType(account_type)
+                ]
               }
               value={confirmPassword}
               onChange={onConfirmPasswordChange}
@@ -102,7 +120,11 @@ const NewPasswordStep = ({
               bgColor={isValid ? 'bg-surface-primary' : 'bg-surface-secondary'}
               fontColor={isValid ? 'text-text-normal' : 'text-text-disabled'}
               isBorder={false}
-              title={signInputTranclation.continue[userLanguage]}
+              title={
+                signInputTranclation.continue[
+                  isEmployerByAccountType(account_type)
+                ]
+              }
               onClick={isValid ? onSubmit : undefined}
             />
           </div>

--- a/src/components/Profile/ProfileMenu.tsx
+++ b/src/components/Profile/ProfileMenu.tsx
@@ -10,6 +10,8 @@ import ToggleBar from '@/assets/icons/Profile/ToggleBar.svg?react';
 import ToggleButton from '@/assets/icons/Profile/ToggleButton.svg?react';
 import { usePatchNotificationAllowed } from '@/hooks/api/useSetting';
 import { useGetUserSummaries } from '@/hooks/api/useProfile';
+import { useUserStore } from '@/store/user';
+import { UserType } from '@/constants/user';
 
 type ProfileMenuProps = {
   title: string;
@@ -24,8 +26,11 @@ const ProfileMenu = ({
   onClick,
   isToggle,
 }: ProfileMenuProps) => {
+  const { account_type } = useUserStore();
   const { mutate: patchNotificationAllowed } = usePatchNotificationAllowed();
-  const { data: notificaionAllowed } = useGetUserSummaries();
+  const { data: notificaionAllowed } = useGetUserSummaries(
+    account_type === UserType.USER,
+  );
 
   const [toggleOn, setToggleOn] = useState<boolean>(false);
 
@@ -36,7 +41,7 @@ const ProfileMenu = ({
         notificaionAllowed.data.user_information.is_notification_allowed,
       );
     }
-  }, []);
+  }, [isToggle, notificaionAllowed]);
 
   const handleToggleChange = () => {
     // 알림 설정 변경

--- a/src/components/Signup/SignupInput.tsx
+++ b/src/components/Signup/SignupInput.tsx
@@ -106,7 +106,11 @@ const SignupInput = ({
   // 비밀번호 유효성 검사를 위한 단일 useEffect
   useEffect(() => {
     const isPasswordValid = debouncedPassword
-      ? validatePassword(debouncedPassword, setPasswordError, pathname)
+      ? validatePassword(
+          debouncedPassword,
+          setPasswordError,
+          isEmployer(pathname),
+        )
       : false;
     const isConfirmValid = confirmPasswordValue === debouncedPassword;
 
@@ -115,7 +119,7 @@ const SignupInput = ({
         debouncedPassword,
         confirmPasswordValue,
         setConfirmPasswordError,
-        pathname,
+        isEmployer(pathname),
       );
     }
 
@@ -133,7 +137,7 @@ const SignupInput = ({
     debouncedPassword,
     confirmPasswordValue,
     pathname,
-    emailVerifyStatus
+    emailVerifyStatus,
   ]);
 
   // 부모 컴포넌트로 값 전달

--- a/src/constants/translation.ts
+++ b/src/constants/translation.ts
@@ -269,6 +269,10 @@ export const profileTranslation = {
     ko: '비밀번호를 확인해주세요',
     en: 'Confirm new password',
   },
+  wrongPassword: {
+    ko: '현재 비밀번호를 다시 확인해주세요.',
+    en: 'Wrong current password input. Try again.',
+  },
   completeTitle: {
     ko: '비밀번호 변경이 완료되었어요!',
     en: 'Your password has been changed!',

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -16,6 +16,7 @@ import {
   patchPassword,
   postRegistrationNumberValidation,
   patchDeviceToken,
+  postValidatePassword,
 } from '@/api/auth';
 import {
   AuthenticationResponse,
@@ -329,6 +330,13 @@ export const usePatchPassword = (
         navigate('/employer/profile/account');
       }
     },
+  });
+};
+
+// 2.12 현재 비밀번호 확인
+export const usePostValidatePassword = () => {
+  return useMutation({
+    mutationFn: postValidatePassword,
   });
 };
 

--- a/src/hooks/api/useProfile.ts
+++ b/src/hooks/api/useProfile.ts
@@ -29,10 +29,11 @@ export const useGetOwnerProfile = () => {
 };
 
 // 3.3 (유학생) 유저 요약 정보 조회하기
-export const useGetUserSummaries = () => {
+export const useGetUserSummaries = (isEnabled: boolean) => {
   return useQuery({
     queryKey: ['userSummaries'],
     queryFn: getUserSummaries,
+    enabled: isEnabled,
   });
 };
 

--- a/src/pages/Profile/ChangePasswordPage.tsx
+++ b/src/pages/Profile/ChangePasswordPage.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
-import { usePatchPassword } from '@/hooks/api/useAuth';
+import { usePatchPassword, usePostValidatePassword } from '@/hooks/api/useAuth';
 import CurrentPasswordStep from '@/components/Profile/Password/CurrentPasswordStep';
 import NewPasswordStep from '@/components/Profile/Password/NewPasswordStep';
 import SuccessStep from '@/components/Profile/Password/SuccessStep';
 import { validatedConfirmPassword, validatePassword } from '@/utils/signin';
-import { useLocation } from 'react-router-dom';
+import { profileTranslation } from '@/constants/translation';
+import { isEmployerByAccountType } from '@/utils/signup';
+import { useUserStore } from '@/store/user';
 
 type PasswordFieldType = 'currentPassword' | 'newPassword' | 'confirmPassword';
 
 const ChangePasswordPage = () => {
-  const { pathname } = useLocation();
+  const { account_type } = useUserStore();
   const [currentStep, setCurrentStep] = useState<number>(1);
   const [currentPassword, setCurrentPassword] = useState('');
   const [passwordError, setPasswordError] = useState<string | null>(null);
@@ -19,7 +21,11 @@ const ChangePasswordPage = () => {
   const [confirmPasswordError, setConfirmPasswordError] = useState<
     string | null
   >(null);
-  const [isValid, setIsValid] = useState<boolean>(false);
+  const [isValidStep1, setIsValidStep1] = useState<boolean>(false);
+  const [isValidStep2, setIsValidStep2] = useState<boolean>(false);
+
+  const { mutateAsync: validateCurrentPassword } = usePostValidatePassword();
+
   const { mutate: changePassword } = usePatchPassword({
     onSuccess: () => {
       setCurrentStep((prev) => prev + 1);
@@ -28,18 +34,23 @@ const ChangePasswordPage = () => {
 
   const handlePasswordChange = (field: PasswordFieldType, value: string) => {
     switch (field) {
-      case 'currentPassword':
+      case 'currentPassword': {
         setCurrentPassword(value);
-        setPasswordError(null);
+        const isNewPasswordValid = validatePassword(
+          value,
+          setPasswordError,
+          isEmployerByAccountType(account_type),
+        );
+        setIsValidStep1(isNewPasswordValid);
         break;
-
+      }
       case 'newPassword': {
         setNewPassword(value);
         // 새 비밀번호 유효성 검사
         const isNewPasswordValid = validatePassword(
           value,
           setNewPasswordError,
-          pathname,
+          isEmployerByAccountType(account_type),
         );
         // 비밀번호 확인 재검증
         if (confirmPassword) {
@@ -47,10 +58,10 @@ const ChangePasswordPage = () => {
             value, // 새로운 비밀번호 값
             confirmPassword,
             setConfirmPasswordError,
-            pathname,
+            isEmployerByAccountType(account_type),
           );
         }
-        setIsValid(isNewPasswordValid && confirmPassword === value);
+        setIsValidStep2(isNewPasswordValid && confirmPassword === value);
         break;
       }
 
@@ -61,23 +72,29 @@ const ChangePasswordPage = () => {
           newPassword,
           value,
           setConfirmPasswordError,
-          pathname,
+          isEmployerByAccountType(account_type),
         );
         const isNewPasswordValid = validatePassword(
           newPassword,
           setNewPasswordError,
-          pathname,
+          isEmployerByAccountType(account_type),
         );
-        setIsValid(isNewPasswordValid && isConfirmValid);
+        setIsValidStep2(isNewPasswordValid && isConfirmValid);
         break;
       }
     }
   };
 
-  const handleCurrentPasswordSubmit = () => {
-    // 비밀번호 확인 api 호출
-    // onSuccess
-    setCurrentStep(2);
+  const handleCurrentPasswordSubmit = async () => {
+    const result = await validateCurrentPassword({
+      password: currentPassword,
+    });
+
+    if (result.data.is_valid) setCurrentStep((prev) => prev + 1);
+    else
+      alert(
+        profileTranslation.wrongPassword[isEmployerByAccountType(account_type)],
+      );
   };
 
   const handleChangePasswordSubmit = () => {
@@ -98,6 +115,7 @@ const ChangePasswordPage = () => {
             }
             onSubmit={handleCurrentPasswordSubmit}
             error={passwordError}
+            isValid={isValidStep1}
           />
         );
       case 2:
@@ -116,7 +134,7 @@ const ChangePasswordPage = () => {
             setNewPasswordError={setNewPasswordError}
             confirmPasswordError={confirmPasswordError}
             setConfirmPasswordError={setConfirmPasswordError}
-            isValid={isValid}
+            isValid={isValidStep2}
           />
         );
       case 3:
@@ -124,11 +142,7 @@ const ChangePasswordPage = () => {
     }
   };
 
-  return (
-    <>
-      {renderStep()}
-    </>
-  );
+  return <>{renderStep()}</>;
 };
 
 export default ChangePasswordPage;

--- a/src/pages/Profile/ProfilePage.tsx
+++ b/src/pages/Profile/ProfilePage.tsx
@@ -14,7 +14,7 @@ const ProfilePage = () => {
   const [bottomSheetOpen, setBottomSheetOpen] = useState<boolean>(false);
   const { pathname } = useLocation();
 
-  const { data } = useGetUserSummaries();
+  const { data } = useGetUserSummaries(true);
 
   // 로그아웃 바텀시트 핸들러
   const handleLogoutClick = () => {

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -71,4 +71,8 @@ export type PolicyResponse = {
 export type ChangePasswordRequest = {
   current_password: string;
   new_password: string;
-}
+};
+
+export type CurrentPasswordRequest = {
+  password: string;
+};

--- a/src/utils/signin.ts
+++ b/src/utils/signin.ts
@@ -20,14 +20,12 @@ export const validateId = (
 export const validatePassword = (
   password: string,
   setPasswordError: (error: string | null) => void,
-  pathname: string,
+  language: 'ko' | 'en',
 ): boolean => {
   const passwordRegex =
     /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[a-zA-Z\d@$!%*?&]{8,20}$/;
   if (!passwordRegex.test(password)) {
-    setPasswordError(
-      signInputTranclation.invalidPassword[isEmployer(pathname)],
-    );
+    setPasswordError(signInputTranclation.invalidPassword[language]);
     return false;
   }
   setPasswordError(null);
@@ -39,11 +37,11 @@ export const validatedConfirmPassword = (
   password: string,
   confirmPassword: string,
   setConfirmPasswordError: (error: string | null) => void,
-  pathname: string,
+  language: 'ko' | 'en',
 ): boolean => {
   if (confirmPassword !== password) {
     setConfirmPasswordError(
-      signInputTranclation.invalidConfirmPassword[isEmployer(pathname)],
+      signInputTranclation.invalidConfirmPassword[language],
     );
     return false;
   }


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- #288

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 고용주 계정 설정 페이지 들어갔을 때 유학생 전용 api 조회하는 에러
- 비밀번호 변경 페이지에서 현재 비밀번호 검증 api로 검증 후에 step2로 넘어가도록 변경하기 + 고용주인 경우 한글 처리 추가


https://github.com/user-attachments/assets/5d73d8ce-93c1-432d-a657-8dcc9cf339ea



## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 비밀번호 변경 프로세스가 개선되어, 현재 비밀번호를 비동기적으로 확인한 후 다음 단계로 진행합니다.
  - 사용자 계정 유형에 따른 동적 현지화가 적용되어, 입력 필드의 텍스트와 에러 메시지가 보다 명확하게 표시됩니다.
  - 프로필 정보 조회 및 가입 단계에서 비밀번호 유효성 검증 로직이 향상되어, 안정적이고 원활한 사용자 경험을 제공합니다.
  - 잘못된 현재 비밀번호 입력 시 사용자에게 피드백 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->