### PR TITLE
[Fix/288] 생년월일 입력을 받는 모든 date picker → input field(YYYY-MM-DD)로 변경

### DIFF
--- a/src/components/Common/Dropdown.tsx
+++ b/src/components/Common/Dropdown.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import ArrowIcon from '@/assets/icons/ArrowUp.tsx';
-import DatePicker from '@/components/Common/DatePicker';
 
 // Dropdown 컴포넌트의 props 타입을 정의합니다.
 type DropDownProps = {
@@ -8,7 +7,6 @@ type DropDownProps = {
   value: string | null; // 현재 선택된 값
   placeholder: string; // 플레이스홀더 텍스트
   options: Array<string>; // 드롭다운 옵션 목록
-  isCalendar?: boolean; // 캘린더 모드 여부 (선택적)
   setValue: (value: string) => void; // 선택된 값을 설정하는 함수
 };
 
@@ -46,7 +44,6 @@ const Dropdown = ({
   value,
   placeholder,
   options,
-  isCalendar,
   setValue,
 }: DropDownProps) => {
   // 드롭다운의 열림/닫힘 상태를 관리합니다.
@@ -96,15 +93,11 @@ const Dropdown = ({
         </div>
         {/* 드롭다운 선택지 모달 (열려있을 때만 표시) */}
         {isOpen ? (
-          isCalendar ? (
-            <DatePicker setSelectedDate={handleSelect} />
-          ) : (
-            <DropdownModal
-              value={value ?? ''}
-              options={options}
-              onSelect={handleSelect}
-            />
-          )
+          <DropdownModal
+            value={value ?? ''}
+            options={options}
+            onSelect={handleSelect}
+          />
         ) : null}
       </div>
     </div>

--- a/src/components/Employer/PostCreate/Step2.tsx
+++ b/src/components/Employer/PostCreate/Step2.tsx
@@ -1,6 +1,5 @@
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
-import Dropdown from '@/components/Common/Dropdown';
 import Input from '@/components/Common/Input';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 import { InputType } from '@/types/common/input';
@@ -13,6 +12,7 @@ import { formatDateToDash } from '@/utils/editResume';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import { documentTranslation } from '@/constants/translation';
+import { formatDateInput } from '@/utils/information';
 
 const Step2 = ({
   postInfo,
@@ -167,24 +167,20 @@ const Step2 = ({
             </div>
             {/* 날짜 선택 입력 */}
             <InputLayout title="공고 종료일" isEssential>
-              <Dropdown
-                value={
-                  newPostInfo.body.recruitment_dead_line === null
-                    ? ''
-                    : newPostInfo.body.recruitment_dead_line
-                }
-                placeholder="날짜 선택"
-                options={[]}
-                isCalendar={true}
-                setValue={(value) =>
+              <Input
+                inputType={InputType.TEXT}
+                placeholder="YYYY-MM-DD"
+                value={newPostInfo.body.recruitment_dead_line || ''}
+                onChange={(value) =>
                   setNewPostInfo({
                     ...newPostInfo,
                     body: {
                       ...newPostInfo.body,
-                      recruitment_dead_line: formatDateToDash(value),
+                      recruitment_dead_line: formatDateInput(value),
                     },
                   })
                 }
+                canDelete={false}
               />
             </InputLayout>
             <div className="w-full relative flex items-center justify-start py-2 gap-3 text-left body-3 text-text-alternative">

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -30,12 +30,12 @@ import {
 } from '@/utils/document';
 import {
   formatCompanyRegistrationNumber,
+  formatDateInput,
   formatPhoneNumber,
   limitInputValueLength,
   parsePhoneNumber,
 } from '@/utils/information';
 import { phone } from '@/constants/information';
-import { formatDateToDash } from '@/utils/editResume';
 import AddTimeIcon from '@/assets/icons/FileAddIcon.svg?react';
 import WorkDayTimeWithRestBottomSheet from '@/components/Common/WorkDayTimeWithRestBottomSheet';
 import RadioButton from '@/components/Information/RadioButton';
@@ -239,40 +239,32 @@ const EmployerLaborContractForm = ({
             </InputLayout>
             {/* 근무 시작일 선택 입력 */}
             <InputLayout title="근무 시작일" isEssential>
-              <Dropdown
-                value={
-                  newDocumentData.start_date === null
-                    ? ''
-                    : newDocumentData.start_date
-                }
-                placeholder="날짜선택"
-                options={[]}
-                isCalendar={true}
-                setValue={(value) =>
+              <Input
+                inputType={InputType.TEXT}
+                placeholder="YYYY-MM-DD"
+                value={newDocumentData.start_date || ''}
+                onChange={(value) =>
                   setNewDocumentData({
                     ...newDocumentData,
-                    start_date: formatDateToDash(value),
+                    start_date: formatDateInput(value),
                   })
                 }
+                canDelete={false}
               />
             </InputLayout>
             {/* 근무 종료일 선택 입력 */}
             <InputLayout title="근무 종료일" isEssential>
-              <Dropdown
-                value={
-                  newDocumentData.end_date === null
-                    ? ''
-                    : newDocumentData.end_date
-                }
-                placeholder="날짜선택"
-                options={[]}
-                isCalendar={true}
-                setValue={(value) =>
+              <Input
+                inputType={InputType.TEXT}
+                placeholder="YYYY-MM-DD"
+                value={newDocumentData.end_date || ''}
+                onChange={(value) =>
                   setNewDocumentData({
                     ...newDocumentData,
-                    end_date: formatDateToDash(value),
+                    end_date: formatDateInput(value),
                   })
                 }
+                canDelete={false}
               />
             </InputLayout>
             {/* 대표자 이름 입력 */}

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -3,6 +3,7 @@ import { initialUserInfo, UserInfoRequestBody } from '@/types/api/users';
 import { UserInfo } from '@/types/api/users';
 import { useEffect, useState } from 'react';
 import {
+  formatDateInput,
   formatPhoneNumber,
   isValidName,
   isValidPhoneNumber,
@@ -153,14 +154,17 @@ const InformationStep = ({
           </InputLayout>
           {/* 생년월일 선택 */}
           <InputLayout title="Date of birth" isEssential={false} isOptional>
-            <Dropdown
-              value={newUserInfo.birth}
-              placeholder="Select Date"
-              options={[]}
-              isCalendar={true}
-              setValue={(value) =>
-                setNewUserInfo({ ...newUserInfo, birth: value })
+            <Input
+              inputType={InputType.TEXT}
+              placeholder="YYYY-MM-DD"
+              value={newUserInfo.birth || ''}
+              onChange={(value) =>
+                setNewUserInfo({
+                  ...newUserInfo,
+                  birth: formatDateInput(value),
+                })
               }
+              canDelete={false}
             />
           </InputLayout>
           {/* 국적 선택 */}

--- a/src/components/Profile/Password/CurrentPasswordStep.tsx
+++ b/src/components/Profile/Password/CurrentPasswordStep.tsx
@@ -18,7 +18,6 @@ interface CurrentPasswordStepProps {
   onPasswordChange: (value: string) => void;
   onSubmit: () => void;
   error: string | null;
-  isValid: boolean;
 }
 
 const CurrentPasswordStep = ({
@@ -26,7 +25,6 @@ const CurrentPasswordStep = ({
   onPasswordChange,
   onSubmit,
   error,
-  isValid,
 }: CurrentPasswordStepProps) => {
   const { account_type } = useUserStore();
   const navigate = useNavigate();
@@ -79,15 +77,21 @@ const CurrentPasswordStep = ({
           <div className="w-full">
             <Button
               type="large"
-              bgColor={isValid ? 'bg-surface-primary' : 'bg-surface-secondary'}
-              fontColor={isValid ? 'text-text-normal' : 'text-text-disabled'}
+              bgColor={
+                password?.length > 0
+                  ? 'bg-surface-primary'
+                  : 'bg-surface-secondary'
+              }
+              fontColor={
+                password?.length > 0 ? 'text-text-normal' : 'text-text-disabled'
+              }
               isBorder={false}
               title={
                 signInputTranclation.continue[
                   isEmployerByAccountType(account_type)
                 ]
               }
-              onClick={isValid ? onSubmit : undefined}
+              onClick={password?.length > 0 ? onSubmit : undefined}
             />
           </div>
         </BottomButtonPanel>

--- a/src/components/SetEducation/EducationPatch.tsx
+++ b/src/components/SetEducation/EducationPatch.tsx
@@ -9,6 +9,7 @@ import { EducationLevels } from '@/constants/manageResume';
 import GraySearchIcon from '@/assets/icons/ManageResume/GraySearchIcon.svg?react';
 import { useState } from 'react';
 import SearchSchools from '@/components/SetEducation/SearchSchools';
+import { formatDateInput } from '@/utils/information';
 
 type EducationPatchProps = {
   educationData: PostEducationType;
@@ -37,13 +38,6 @@ const EducationPatch = ({
   const handleNumberChange = (field: 'grade' | 'gpa', value: string) => {
     const formmateedvalue = value == 'null' ? '' : value;
     handleInputChange(field, formmateedvalue);
-  };
-
-  const handleDateChange = (
-    field: 'start_date' | 'end_date',
-    value: string,
-  ) => {
-    handleInputChange(field, value.replace(/\//g, '-'));
   };
 
   return (
@@ -138,12 +132,14 @@ const EducationPatch = ({
           <p className="body-3 text-[#1E1926] px-1 py-2">
             Entrance Date <span className="text-[#EE4700] body-1">*</span>
           </p>
-          <Dropdown
-            value={educationData.start_date.replace(/-/g, '/')}
-            placeholder="Select Date"
-            options={[]}
-            isCalendar={true}
-            setValue={(value) => handleDateChange('start_date', value)}
+          <Input
+            inputType={InputType.TEXT}
+            placeholder="YYYY-MM-DD"
+            value={educationData.start_date || ''}
+            onChange={(value) =>
+              handleInputChange('start_date', formatDateInput(value))
+            }
+            canDelete={false}
           />
         </div>
         {/* 졸업 날짜 입력 */}
@@ -151,12 +147,14 @@ const EducationPatch = ({
           <p className="body-3 text-[#1E1926] px-1 py-2">
             Graduation Date <span className="text-[#EE4700] body-1">*</span>
           </p>
-          <Dropdown
-            value={educationData.end_date?.replace(/-/g, '/')}
-            placeholder="Select Date"
-            options={[]}
-            isCalendar={true}
-            setValue={(value) => handleDateChange('end_date', value)}
+          <Input
+            inputType={InputType.TEXT}
+            placeholder="YYYY-MM-DD"
+            value={educationData.end_date || ''}
+            onChange={(value) =>
+              handleInputChange('end_date', formatDateInput(value))
+            }
+            canDelete={false}
           />
         </div>
       </div>

--- a/src/components/SetEducation/EducationPost.tsx
+++ b/src/components/SetEducation/EducationPost.tsx
@@ -7,6 +7,7 @@ import GraySearchIcon from '@/assets/icons/ManageResume/GraySearchIcon.svg?react
 import { useState } from 'react';
 import SearchSchools from '@/components/SetEducation/SearchSchools';
 import { School } from '@/types/api/document';
+import { formatDateInput } from '@/utils/information';
 
 type EducationPostProps = {
   educationData: InitailEducationType;
@@ -29,13 +30,6 @@ const EducationPost = ({
     value: string | number,
   ) => {
     setEducationData((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleDateChange = (
-    field: 'start_date' | 'end_date',
-    value: string,
-  ) => {
-    handleInputChange(field, value.replace(/\//g, '-'));
   };
 
   return (
@@ -126,16 +120,14 @@ const EducationPost = ({
           <p className="body-3 text-[#1E1926] px-1 py-2">
             Entrance Date <span className="text-[#EE4700] body-1">*</span>
           </p>
-          <Dropdown
-            value={
-              educationData.start_date
-                ? educationData.start_date.replace(/-/g, '/')
-                : null
+          <Input
+            inputType={InputType.TEXT}
+            placeholder="YYYY-MM-DD"
+            value={educationData.start_date || ''}
+            onChange={(value) =>
+              handleInputChange('start_date', formatDateInput(value))
             }
-            placeholder="Select Date"
-            options={[]}
-            isCalendar={true}
-            setValue={(value) => handleDateChange('start_date', value)}
+            canDelete={false}
           />
         </div>
         {/* 졸업 날짜 입력 */}
@@ -143,16 +135,14 @@ const EducationPost = ({
           <p className="body-3 text-[#1E1926] px-1 py-2">
             Graduation Date <span className="text-[#EE4700] body-1">*</span>
           </p>
-          <Dropdown
-            value={
-              educationData.end_date
-                ? educationData.end_date.replace(/-/g, '/')
-                : null
+          <Input
+            inputType={InputType.TEXT}
+            placeholder="YYYY-MM-DD"
+            value={educationData.end_date || ''}
+            onChange={(value) =>
+              handleInputChange('end_date', formatDateInput(value))
             }
-            placeholder="Select Date"
-            options={[]}
-            isCalendar={true}
-            setValue={(value) => handleDateChange('end_date', value)}
+            canDelete={false}
           />
         </div>
       </div>

--- a/src/components/WorkExperience/WorkExperiencePatch.tsx
+++ b/src/components/WorkExperience/WorkExperiencePatch.tsx
@@ -1,9 +1,9 @@
 import { InputType } from '@/types/common/input';
 import Input from '@/components/Common/Input';
 import { useEffect, useRef, useState, ChangeEvent } from 'react';
-import Dropdown from '@/components/Common/Dropdown';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 import { WorkExperienctRequest } from '@/types/api/resumes';
+import { formatDateInput } from '@/utils/information';
 
 type WorkExperiencePatchProps = {
   workExperienceData: WorkExperienctRequest;
@@ -89,22 +89,26 @@ const WorkExperiencePatch = ({
       </InputLayout>
       {/* 시작 날짜 입력 */}
       <InputLayout title="Start Date" isEssential={true}>
-        <Dropdown
-          value={workExperienceData.start_date.replace(/-/g, '/')}
-          placeholder="Select Date"
-          options={[]}
-          isCalendar={true}
-          setValue={(value) => handleDateChange('start_date', value)}
+        <Input
+          inputType={InputType.TEXT}
+          placeholder="YYYY-MM-DD"
+          value={workExperienceData.start_date || ''}
+          onChange={(value) =>
+            handleDateChange('start_date', formatDateInput(value))
+          }
+          canDelete={false}
         />
       </InputLayout>
       {/* 끝 날짜 입력 */}
       <InputLayout title="End Date" isEssential={true} width="w-fit">
-        <Dropdown
-          value={workExperienceData.end_date?.replace(/-/g, '/')}
-          placeholder="Select Date"
-          options={[]}
-          isCalendar={true}
-          setValue={(value) => handleDateChange('end_date', value)}
+        <Input
+          inputType={InputType.TEXT}
+          placeholder="YYYY-MM-DD"
+          value={workExperienceData.end_date || ''}
+          onChange={(value) =>
+            handleDateChange('end_date', formatDateInput(value))
+          }
+          canDelete={false}
         />
         <div
           className="flex items-center gap-3 mt-2 cursor-pointer"

--- a/src/components/WorkExperience/WorkExperiencePost.tsx
+++ b/src/components/WorkExperience/WorkExperiencePost.tsx
@@ -1,9 +1,9 @@
 import { InputType } from '@/types/common/input';
 import Input from '@/components/Common/Input';
 import { useEffect, useRef, useState, ChangeEvent } from 'react';
-import Dropdown from '@/components/Common/Dropdown';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 import { WorkExperienctRequest } from '@/types/api/resumes';
+import { formatDateInput } from '@/utils/information';
 
 type WorkExperiencePostProps = {
   workExperienceData: WorkExperienctRequest;
@@ -93,22 +93,26 @@ const WorkExperiencePost = ({
       </InputLayout>
       {/* 시작 날짜 입력 */}
       <InputLayout title="Start Date" isEssential={true}>
-        <Dropdown
-          value={workExperienceData.start_date.replace(/-/g, '/')}
-          placeholder="Select Date"
-          options={[]}
-          isCalendar={true}
-          setValue={(value) => handleDateChange('start_date', value)}
+        <Input
+          inputType={InputType.TEXT}
+          placeholder="YYYY-MM-DD"
+          value={workExperienceData.start_date || ''}
+          onChange={(value) =>
+            handleDateChange('start_date', formatDateInput(value))
+          }
+          canDelete={false}
         />
       </InputLayout>
       {/* 끝 날짜 입력 */}
       <InputLayout title="End Date" isEssential={true}>
-        <Dropdown
-          value={workExperienceData.end_date?.replace(/-/g, '/')}
-          placeholder="Select Date"
-          options={[]}
-          isCalendar={true}
-          setValue={(value) => handleDateChange('end_date', value)}
+        <Input
+          inputType={InputType.TEXT}
+          placeholder="YYYY-MM-DD"
+          value={workExperienceData.end_date || ''}
+          onChange={(value) =>
+            handleDateChange('end_date', formatDateInput(value))
+          }
+          canDelete={false}
         />
         <div
           className="flex items-center gap-3 mt-2 cursor-pointer"

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/hooks/api/useDocument';
 import {
   formatCompanyRegistrationNumber,
+  formatDateInput,
   formatPhoneNumber,
   parsePhoneNumber,
 } from '@/utils/information';
@@ -212,14 +213,17 @@ const IntegratedApplicationWriteForm = ({
             </InputLayout>
             {/* 생일 입력 */}
             <InputLayout title="Date Of Birth" isEssential>
-              <Dropdown
-                value={newDocumentData.birth}
-                placeholder="Select Date"
-                options={[]}
-                isCalendar={true}
-                setValue={(value) =>
-                  setNewDocumentData({ ...newDocumentData, birth: value })
+              <Input
+                inputType={InputType.TEXT}
+                placeholder="YYYY-MM-DD"
+                value={newDocumentData.birth || ''}
+                onChange={(value) =>
+                  setNewDocumentData({
+                    ...newDocumentData,
+                    birth: formatDateInput(value),
+                  })
                 }
+                canDelete={false}
               />
             </InputLayout>
             {/* 성별 입력 */}

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -26,6 +26,7 @@ import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import DaumPostcodeEmbed, { Address } from 'react-daum-postcode';
 import { convertToAddress, getAddressCoords } from '@/utils/map';
 import { documentTranslation } from '@/constants/translation';
+import { formatDateInput } from '@/utils/information';
 
 const EditProfilePage = () => {
   const { data: userProfile } = useGetUserProfile();
@@ -213,14 +214,14 @@ const EditProfilePage = () => {
               </InputLayout>
               {/* 생년월일 선택 */}
               <InputLayout title="Date of birth" isEssential={false} isOptional>
-                <Dropdown
-                  value={userData.birth.replace(/-/g, '/')}
-                  placeholder="Select Date"
-                  options={[]}
-                  isCalendar={true}
-                  setValue={(value) =>
-                    setUserData({ ...userData, birth: value })
+                <Input
+                  inputType={InputType.TEXT}
+                  placeholder="YYYY-MM-DD"
+                  value={userData.birth || ''}
+                  onChange={(value) =>
+                    setUserData({ ...userData, birth: formatDateInput(value) })
                   }
+                  canDelete={false}
                 />
               </InputLayout>
               {/* 국적 선택 */}

--- a/src/pages/Profile/ChangePasswordPage.tsx
+++ b/src/pages/Profile/ChangePasswordPage.tsx
@@ -21,7 +21,6 @@ const ChangePasswordPage = () => {
   const [confirmPasswordError, setConfirmPasswordError] = useState<
     string | null
   >(null);
-  const [isValidStep1, setIsValidStep1] = useState<boolean>(false);
   const [isValidStep2, setIsValidStep2] = useState<boolean>(false);
 
   const { mutateAsync: validateCurrentPassword } = usePostValidatePassword();
@@ -36,12 +35,7 @@ const ChangePasswordPage = () => {
     switch (field) {
       case 'currentPassword': {
         setCurrentPassword(value);
-        const isNewPasswordValid = validatePassword(
-          value,
-          setPasswordError,
-          isEmployerByAccountType(account_type),
-        );
-        setIsValidStep1(isNewPasswordValid);
+        setPasswordError(null);
         break;
       }
       case 'newPassword': {
@@ -115,7 +109,6 @@ const ChangePasswordPage = () => {
             }
             onSubmit={handleCurrentPasswordSubmit}
             error={passwordError}
-            isValid={isValidStep1}
           />
         );
       case 2:

--- a/src/utils/information.ts
+++ b/src/utils/information.ts
@@ -60,8 +60,8 @@ const validateCompanyRegistrationNumber = (value: string): boolean => {
   for (let i = 0; i < value.length; i++) {
     if (i === 3 || i === 6) {
       if (value[i] !== '/') return false; // 3, 6번째는 / 필수
-    } else {
-      if (!/^\d$/.test(value[i])) return false; // 나머지는 숫자만 가능
+    } else if (!/^\d$/.test(value[i])) {
+      return false; // 나머지는 숫자만 가능
     }
   }
   return true;
@@ -78,6 +78,35 @@ export const formatCompanyRegistrationNumber = (value: string) => {
       ?.slice(1)
       .filter(Boolean)
       .join('/') || '';
+
+  return formatValue;
+};
+
+// 날짜값 입력 시 YYYY-MM-DD 형식으로 만들기
+const validateDateInput = (value: string) => {
+  if (value.length > 10) return false;
+
+  for (let i = 0; i < value.length; i++) {
+    if (i === 4 || i === 7) {
+      if (value[i] !== '-') return false;
+    } else if (!/^\d$/.test(value[i])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const formatDateInput = (value: string) => {
+  if (validateDateInput(value)) return value;
+
+  const numberValue = value.replace(/\D/g, '').slice(0, 8);
+
+  const formatValue =
+    numberValue
+      .match(/(\d{1,4})(\d{1,2})?(\d{1,2})?/)
+      ?.slice(1)
+      .filter(Boolean)
+      .join('-') || '';
 
   return formatValue;
 };


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #288

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 이전 pr에서 비밀번호 변경 페이지에서 현재 비밀번호는 임시 토큰인 경우가 있어서 유효성 검사 로직을 제거
- 생년월일 입력을 받는 모든 date picker → input field(YYYY-MM-DD)로 변경. 자동으로 YYYY-MM-DD로 작성되도록 구현


https://github.com/user-attachments/assets/4b8c5b9a-313e-4b49-ba92-391d1b0a29d5





## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 날짜 입력 방식이 달력 기반 선택에서 "YYYY-MM-DD" 형식의 텍스트 입력으로 전면 변경되었습니다.
  - 날짜 입력 시 자동 검증 및 형식 수정 기능이 추가되어 사용자가 올바른 형식으로 입력할 수 있습니다.

- **리팩토링**
  - 비밀번호 입력 검증 로직이 단순화되어, 입력된 값의 존재 여부만을 기준으로 작동합니다.
  - 조건부 렌더링 로직이 개선되어 보다 직관적인 사용자 인터페이스를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->