### PR TITLE
[Fix/295] - 로그인 후 fcm 토큰 등록, 푸시 메시지 전송

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -84,13 +84,11 @@ export const patchDeviceToken = async ({
   deviceToken: string;
   deviceId: string;
 }): Promise<RESTYPE<null>> => {
-  console.log(deviceId, deviceToken);
   try {
     const response = await api.patch('/auth/device-token', {
       device_token: deviceToken,
       device_id: deviceId,
     });
-    console.log(response.data);
     return response.data;
   } catch (error: unknown) {
     // 에러 타입 명시적 처리

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -85,11 +85,31 @@ export const patchDeviceToken = async ({
   deviceId: string;
 }): Promise<RESTYPE<null>> => {
   console.log(deviceId, deviceToken);
-  const response = await api.patch('/auth/device-token', {
-    device_token: deviceToken,
-    device_id: deviceId,
-  });
-  return response.data;
+  try {
+    const response = await api.patch('/auth/device-token', {
+      device_token: deviceToken,
+      device_id: deviceId,
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error: unknown) {
+    // 에러 타입 명시적 처리
+    if (axios.isAxiosError(error)) {
+      // Axios 에러인 경우
+      console.error('디바이스 토큰 갱신 API 오류:', {
+        message: error.message,
+        status: error.response?.status,
+        data: error.response?.data,
+      });
+    } else if (error instanceof Error) {
+      // 일반 Error 객체인 경우
+      console.error('디바이스 토큰 갱신 일반 오류:', error.message);
+    } else {
+      // 기타 알 수 없는 오류
+      console.error('디바이스 토큰 갱신 알 수 없는 오류:', error);
+    }
+    throw error; // 오류 다시 던지기
+  }
 };
 
 // 2.1 아이디 중복검사

--- a/src/components/Common/ReactNativeMessageListener.tsx
+++ b/src/components/Common/ReactNativeMessageListener.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { setupReactNativeMessageListener } from '@/utils/reactNativeMessage';
 import { usePatchDeviceToken } from '@/hooks/api/useAuth';
 import { useNavigate } from 'react-router-dom';
@@ -11,23 +11,45 @@ interface ReactNativeMessage {
   payload?: string | FCMTokenPayload;
 }
 export const ReactNativeMessageListener = () => {
+  const [tokenData, setTokenData] = useState<{
+    deviceToken: string;
+    deviceId: string;
+  } | null>(null);
+
   const { mutate: patchDeviceToken } = usePatchDeviceToken();
   const navigate = useNavigate();
-  // 메시지 리스너 함수
+  // 상태가 변경될 때 API 호출
   useEffect(() => {
-    const cleanup = setupReactNativeMessageListener(
+    if (tokenData) {
+      console.log('상태 변경에 의한 API 호출:', tokenData);
+      patchDeviceToken(tokenData);
+    }
+  }, [tokenData, patchDeviceToken]);
+
+  useEffect(() => {
+    // 메시지 리스너
+    const messageHandler = setupReactNativeMessageListener(
       (data: ReactNativeMessage) => {
         if (data.type === 'FCMTOKEN' && data.payload !== undefined) {
-          const { deviceToken, deviceId } = data.payload as FCMTokenPayload;
-          patchDeviceToken({ deviceToken: deviceToken, deviceId: deviceId });
+          try {
+            const payloadObj = JSON.parse(data.payload as string);
+            const { deviceToken, deviceId } = payloadObj as FCMTokenPayload;
+
+            // 직접 API 호출 대신 상태 업데이트
+            setTokenData({ deviceToken, deviceId });
+          } catch (error) {
+            console.error('FCM 토큰 처리 오류:', error);
+          }
         }
+
         if (data.type === 'NOTIFICATION_NAVIGATION') {
           navigate('/alarm');
         }
       },
     );
 
-    return cleanup;
-  }, [patchDeviceToken]);
+    return () => messageHandler();
+  }, [navigate]);
+
   return null;
 };

--- a/src/hooks/api/useAuth.ts
+++ b/src/hooks/api/useAuth.ts
@@ -87,10 +87,12 @@ export const useSignIn = () => {
 
         updateId('');
         updatePassword('');
+
         // 앱에서 FCM 토큰 요청
         sendReactNativeMessage({ type: 'RECEIVE_TOKEN' });
+
+        // 새로고침 전에 지연 추가
         navigate('/splash');
-        window.location.reload();
       }
     },
     onError: () => {
@@ -147,7 +149,7 @@ export const useReIssueToken = () => {
 export const usePatchDeviceToken = () => {
   return useMutation({
     mutationFn: patchDeviceToken,
-    onError: (error) => {
+    onError: (error: Error) => {
       console.error('디바이스 토큰 갱신에 실패했습니다.');
       console.log(error);
     },

--- a/src/pages/Information/InformationPage.tsx
+++ b/src/pages/Information/InformationPage.tsx
@@ -57,7 +57,7 @@ const InformationPage = () => {
       ...userInfo,
       address: userInfo.address.address_name ? userInfo.address : null,
       marketing_allowed: marketingAllowed,
-      notification_allowed: false,
+      notification_allowed: true,
       temporary_token: String(getTemporaryToken()),
       language: language,
       term_types: termTypes,

--- a/src/types/api/employ.ts
+++ b/src/types/api/employ.ts
@@ -40,5 +40,5 @@ export const initialEmployerRegistration: EmployerRegistrationRequestBody = {
     latitude: 0,
   },
   marketing_allowed: false,
-  notification_allowed: false,
+  notification_allowed: true,
 };


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #295 

## Work Description ✏️

- 로그인 후 토큰, deviceID 등록이 실패하던 현상을 수정했습니다.
- 회원가입 시 사용자의 푸시 알림 수신 설정을 기본적으로 허용하도록 수정했습니다.

## Uncompleted Tasks 😅

## To Reviewers 📢

#295 이슈 관련 커밋만 확인해주시면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 보다 견고한 내비게이션 환경을 제공하여, 원활한 페이지 전환과 탐색이 가능합니다.
	- 비밀번호 변경 및 회원가입 과정에서 비동기 유효성 검사와 역할별 맞춤 번역을 통한 명확한 오류 피드백을 제공합니다.
	- 기본 알림 설정이 활성화되어, 업데이트와 관련된 소식을 적시에 받아볼 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->