### PR TITLE
[Fearue/298] - 앱 실행 시 버전 체크

### DIFF
--- a/src/api/version.ts
+++ b/src/api/version.ts
@@ -1,0 +1,14 @@
+import { RESTYPE } from '@/types/api/common';
+import { apiWithoutAuth } from '@/api/index.ts';
+import { VersionType } from '@/types/api/version';
+
+// 0.1 최신 버전 확인하기
+export const getNewestVersion = async (): Promise<RESTYPE<VersionType>> => {
+  const userAgent = navigator.userAgent;
+  console.log(userAgent);
+  const isIOS = /iPhone|iPad|iPod/.test(userAgent);
+  const isAndroid = /Android/.test(userAgent);
+  const deviceOS = isIOS ? 'IOS' : isAndroid ? 'ANDROID' : 'OTHER';
+  const response = await apiWithoutAuth.get(`/versions?os=${deviceOS}`);
+  return response.data;
+};

--- a/src/api/version.ts
+++ b/src/api/version.ts
@@ -5,7 +5,6 @@ import { VersionType } from '@/types/api/version';
 // 0.1 최신 버전 확인하기
 export const getNewestVersion = async (): Promise<RESTYPE<VersionType>> => {
   const userAgent = navigator.userAgent;
-  console.log(userAgent);
   const isIOS = /iPhone|iPad|iPod/.test(userAgent);
   const isAndroid = /Android/.test(userAgent);
   const deviceOS = isIOS ? 'IOS' : isAndroid ? 'ANDROID' : 'OTHER';

--- a/src/components/Common/ReactNativeMessageListener.tsx
+++ b/src/components/Common/ReactNativeMessageListener.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { setupReactNativeMessageListener } from '@/utils/reactNativeMessage';
 import { usePatchDeviceToken } from '@/hooks/api/useAuth';
 import { useNavigate } from 'react-router-dom';
+import { useGetNewestVersion } from '@/hooks/api/useVersion';
 interface FCMTokenPayload {
   deviceToken: string;
   deviceId: string;
@@ -12,6 +13,7 @@ interface ReactNativeMessage {
 }
 export const ReactNativeMessageListener = () => {
   const { mutate: patchDeviceToken } = usePatchDeviceToken();
+  const { mutate: getVersion } = useGetNewestVersion();
   const navigate = useNavigate();
   // 메시지 리스너 함수
   useEffect(() => {
@@ -24,10 +26,13 @@ export const ReactNativeMessageListener = () => {
         if (data.type === 'NOTIFICATION_NAVIGATION') {
           navigate('/alarm');
         }
+        if (data.type === 'CHECKVERSION') {
+          getVersion();
+        }
       },
     );
 
     return cleanup;
-  }, [patchDeviceToken]);
+  }, [patchDeviceToken, getVersion]);
   return null;
 };

--- a/src/hooks/api/useVersion.ts
+++ b/src/hooks/api/useVersion.ts
@@ -9,6 +9,15 @@ export const useGetNewestVersion = () => {
   const { mutate } = useMutation({
     mutationFn: getNewestVersion,
     onSuccess: (response: RESTYPE<VersionType>) => {
+      if (
+        !response?.data ||
+        typeof response.data.major !== 'number' ||
+        typeof response.data.minor !== 'number' ||
+        typeof response.data.patch !== 'number'
+      ) {
+        console.error('유효하지 않은 버전 정보 형식입니다.', response);
+        return;
+      }
       const versionString = `${response.data.major}.${response.data.minor}.${response.data.patch}`;
       sendReactNativeMessage({ type: 'VERSION_CHECK', payload: versionString });
     },

--- a/src/hooks/api/useVersion.ts
+++ b/src/hooks/api/useVersion.ts
@@ -1,0 +1,20 @@
+import { getNewestVersion } from '@/api/version';
+import { RESTYPE } from '@/types/api/common';
+import { VersionType } from '@/types/api/version';
+import { sendReactNativeMessage } from '@/utils/reactNativeMessage';
+import { useMutation } from '@tanstack/react-query';
+
+// 0.1 최신 버전 확인하기
+export const useGetNewestVersion = () => {
+  const { mutate } = useMutation({
+    mutationFn: getNewestVersion,
+    onSuccess: (response: RESTYPE<VersionType>) => {
+      const versionString = `${response.data.major}.${response.data.minor}.${response.data.patch}`;
+      sendReactNativeMessage({ type: 'VERSION_CHECK', payload: versionString });
+    },
+    onError: (error) => {
+      console.error('버전 확인 중 오류 발생:', error);
+    },
+  });
+  return { mutate };
+};

--- a/src/types/api/version.ts
+++ b/src/types/api/version.ts
@@ -1,0 +1,5 @@
+export type VersionType = {
+  major: number;
+  minor: number;
+  patch: number;
+};


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #298 

## Work Description ✏️

- 앱 실행 시 1회 버전 체크를 진행, 구 버전 일시 os별 앱/플레이 스토어로 이동해 설치하도록 안내하는 기능 중 웹 파트
  - 앱과의 버전 체크 bridge 통신 기능
  - 0.1 최신 버전 체크하기 api 연동
<img width="800" alt="이미지다중선택기능시연영상" src="https://github.com/user-attachments/assets/6268f848-b672-4287-b0da-e552cc48a14b" />

## Uncompleted Tasks 😅
## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 앱의 최신 버전 정보를 비동기적으로 확인하는 기능을 추가하여, 사용자의 디바이스(아이폰, 안드로이드 등)에 맞는 업데이트를 제공합니다.
  - 특정 메시지 수신 시 최신 버전 정보를 자동으로 확인 및 전송해 React Native 앱과 연동되는 기능을 도입했습니다.
  - 새로운 커스텀 훅을 사용하여 최신 버전 확인 프로세스를 관리하고, 성공적으로 응답을 받을 경우 버전 정보를 React Native 애플리케이션에 전송합니다.
  - 버전 정보를 구조화하여 표현할 수 있는 새로운 타입 `VersionType`을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->