### PR TITLE
[Fix/312] 이메일 전송 시에 스팸함 안내 문구 추가하기

### DIFF
--- a/src/components/Signup/SignupInput.tsx
+++ b/src/components/Signup/SignupInput.tsx
@@ -288,7 +288,7 @@ const SignupInput = ({
                 <p className="text-blue-600 text-xs p-2">
                   {signInputTranclation.enterCode[isEmployer(pathname)]}
                 </p>
-                <p className="text-[#FF6F61] text-xs p-2 pt-0">
+                <p className="text-[#FF6F61] text-xs px-2 pb-2">
                   {' '}
                   {signInputTranclation.spamEmailInfo[isEmployer(pathname)]}
                 </p>

--- a/src/components/Signup/SignupInput.tsx
+++ b/src/components/Signup/SignupInput.tsx
@@ -284,9 +284,15 @@ const SignupInput = ({
               </div>
             )}
             {emailVerifyStatus === 'sent' && (
-              <p className="text-blue-600 text-xs p-2">
-                {signInputTranclation.enterCode[isEmployer(pathname)]}
-              </p>
+              <>
+                <p className="text-blue-600 text-xs p-2">
+                  {signInputTranclation.enterCode[isEmployer(pathname)]}
+                </p>
+                <p className="text-[#FF6F61] text-xs p-2 pt-0">
+                  {' '}
+                  {signInputTranclation.spamEmailInfo[isEmployer(pathname)]}
+                </p>
+              </>
             )}
             {emailVerifyStatus === 'resent' && (
               <p className="text-blue-600 text-xs p-2">

--- a/src/constants/translation.ts
+++ b/src/constants/translation.ts
@@ -107,6 +107,10 @@ export const signInputTranclation = {
     ko: '인증번호를 보내드렸어요. (5분)',
     en: 'Enter the code from the email we sent you',
   },
+  spamEmailInfo: {
+    ko: '*이메일이 오지 않았나요? 스팸함 또는 프로모션함을 확인해주세요!',
+    en: "*Didn't receive the email? Please check your spam or promotions folder!",
+  },
   resetPasswordVerifySuccess: {
     ko: '인증',
   },

--- a/src/pages/Signin/ResetPasswordPage.tsx
+++ b/src/pages/Signin/ResetPasswordPage.tsx
@@ -201,7 +201,7 @@ const ResetPasswordPage = () => {
                       <p className="text-blue-600 text-xs p-2">
                         {signInputTranclation.enterCode['ko']}
                       </p>
-                      <p className="text-[#FF6F61] text-xs p-2">
+                      <p className="text-[#FF6F61] text-xs px-2 pb-2">
                         {signInputTranclation.spamEmailInfo['ko']}
                       </p>
                     </>

--- a/src/pages/Signin/ResetPasswordPage.tsx
+++ b/src/pages/Signin/ResetPasswordPage.tsx
@@ -197,9 +197,14 @@ const ResetPasswordPage = () => {
                     </div>
                   )}
                   {emailVerifyStatus === 'sent' && (
-                    <p className="text-blue-600 text-xs p-2">
-                      {signInputTranclation.enterCode['ko']}
-                    </p>
+                    <>
+                      <p className="text-blue-600 text-xs p-2">
+                        {signInputTranclation.enterCode['ko']}
+                      </p>
+                      <p className="text-[#FF6F61] text-xs p-2">
+                        {signInputTranclation.spamEmailInfo['ko']}
+                      </p>
+                    </>
                   )}
                   {emailVerifyStatus === 'resent' && (
                     <p className="text-blue-600 text-xs p-2">


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #312

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 이메일 전송 시에 스팸함 안내 문구 추가

<img width="342" alt="스크린샷 2025-04-14 오후 11 40 34" src="https://github.com/user-attachments/assets/90bb7d1c-9870-4892-94dd-589e7982852c" />


## Uncompleted Tasks 😅

[//]: # "없다면 N/A"


## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 이메일 인증 단계에서 스팸 폴더 확인에 관한 추가 안내 메시지가 제공되어, 인증 코드 입력 시 더 명확한 정보를 확인할 수 있습니다.
	- 사용자에게 보다 직관적인 피드백을 위해 안내 메시지의 스타일이 개선되었습니다.
	- 다국어 지원이 강화되어 영어와 한국어 모두에서 일관된 안내를 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->