### PR TITLE
Fix/323 공고 생성 후 뒤로가기 시 작성 페이지로 복귀하는 문제

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -11,5 +11,6 @@ reviews:
   auto_review:
     enabled: true # 자동 리뷰 활성화
     base_branches: ['.*'] # 모든 브랜치에 대해 자동 리뷰
+    ignore_labels: ['no-rabbit-zone'] # 이 라벨이 있는 PR은 리뷰하지 않음
 chat:
   auto_reply: true # 질문에 자동 응답 활성화

--- a/src/pages/Employer/Post/EmployerCreatePostPage.tsx
+++ b/src/pages/Employer/Post/EmployerCreatePostPage.tsx
@@ -36,6 +36,7 @@ const EmployerCreatePostPage = () => {
       setDevIsModal(true);
       smartNavigate(navigate, `/employer/post/${response.data.id}`, {
         delay: 2000,
+        forceSkip: true,
       });
     },
   }); // 공고 생성 시 호출하는 훅


### PR DESCRIPTION
## Related issue 🛠

- closed #323 
## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 공고 작성 후 뒤로가기 시 메인 페이지로 이동하도록 수정

## Uncompleted Tasks 😅

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - `.coderabbit.yml` 설정에서 `no-rabbit-zone` 라벨이 지정된 PR은 자동 리뷰에서 제외되도록 업데이트되었습니다.

- **Refactor**
  - 채용 공고 작성 후 이동 시, 페이지 네비게이션에 `forceSkip: true` 옵션이 추가되어 동작이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->