### PR TITLE
[Fix/322] 이미 지원 완료한 공고 지원 시에 하단 모달 2개 출현하는 오류

### DIFF
--- a/src/hooks/api/useApplication.ts
+++ b/src/hooks/api/useApplication.ts
@@ -30,6 +30,9 @@ export const useGetPostValidation = (id: number, isEnabled: boolean) => {
 export const usePostApplyPost = () => {
   return useMutation({
     mutationFn: postApplyPost,
+    meta: {
+      skipGlobalError: true,
+    },
     onError: (error) => {
       console.error('공고 지원하기 실패', error);
     },

--- a/src/store/error.ts
+++ b/src/store/error.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import { create } from 'zustand';
+
+type ErrorStore = {
+  isOpenServerErrorBottomSheet: boolean;
+  isOpenErrorBottomSheet: boolean;
+  errorMessage: string;
+  setIsOpenServerErrorBottomSheet: (isOpen: boolean) => void;
+  setIsOpenErrorBottomSheet: (isOpen: boolean) => void;
+  openErrorBottomSheet: (error: unknown) => void;
+};
+
+export const useErrorStore = create<ErrorStore>((set) => ({
+  isOpenServerErrorBottomSheet: false,
+  isOpenErrorBottomSheet: false,
+  errorMessage: '',
+  setIsOpenServerErrorBottomSheet: (isOpen) =>
+    set(() => ({ isOpenServerErrorBottomSheet: isOpen })),
+  setIsOpenErrorBottomSheet: (isOpen) =>
+    set(() => ({ isOpenErrorBottomSheet: isOpen })),
+  openErrorBottomSheet: (error) => {
+    if (!axios.isAxiosError(error)) return;
+
+    if (error.response?.status === 500 || error.response?.status === 408) {
+      set({ isOpenServerErrorBottomSheet: true });
+    } else if (error.response?.status !== 401) {
+      set({
+        isOpenErrorBottomSheet: true,
+        errorMessage: error.response?.data?.error?.message ?? '',
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #322

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 에러 처리를 zustand로 상태 관리하여 선택적으로 전역 에러 처리 가능하도록 수정했습니다. meta 값을 동적으로는 부여할 수가 없어서 특정 경우는 별도로 에러 처리를 하고 나머지는 전역적으로 에러 처리를 하기 위해서 useErrorStore를 구현하는 방법을 사용했습니다! 혹시 더 나은 방법이 생각나면 코멘트해주세요!!


https://github.com/user-attachments/assets/45319e5d-3621-4e44-8b74-83f1c3faa2bf



## Uncompleted Tasks 😅

[//]: # "없다면 N/A"


## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 에러 상태와 표시를 중앙 집중식 에러 스토어에서 관리하도록 개선되었습니다.
	- 글로벌 에러 바텀시트가 추가되어 서버 에러와 일반 에러를 구분하여 안내합니다.

- **버그 수정**
	- 특정 조건에서 글로벌 에러 핸들러를 건너뛸 수 있도록 처리되었습니다.

- **리팩터링**
	- 에러 처리 로직이 각 컴포넌트의 로컬 상태에서 전역 스토어로 이동되어 코드가 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->