### PR TITLE
🐛 fix: 회원가입 중 이름 입력 시 공백 허용 및 공백 길이 자동 조절 #327

### DIFF
--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -84,13 +84,10 @@ const InformationStep = ({
         newUserInfo.last_name &&
         newUserInfo.last_name.replace(/\s+/g, ' ').trim(),
       nationality:
-        newUserInfo.nationality === null
-          ? null
-          : newUserInfo.nationality.toUpperCase().replace(/\s/g, '_'),
+        newUserInfo.nationality?.toUpperCase().replace(/\s/g, '_') ?? null,
       birth: formatDateToDash(newUserInfo.birth as string),
       phone_number: phoneNum,
-      visa:
-        newUserInfo.visa !== null ? newUserInfo.visa.replace(/-/g, '_') : '',
+      visa: newUserInfo.visa?.replace(/-/g, '_') ?? '',
     };
   };
 

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -77,15 +77,13 @@ const InformationStep = ({
   ): UserInfo => {
     return {
       ...newUserInfo,
-      first_name:
-        newUserInfo.first_name &&
-        newUserInfo.first_name.replace(/\s+/g, ' ').trim(),
-      last_name:
-        newUserInfo.last_name &&
-        newUserInfo.last_name.replace(/\s+/g, ' ').trim(),
+      first_name: newUserInfo.first_name?.replace(/\s+/g, ' ').trim() ?? null,
+      last_name: newUserInfo.last_name?.replace(/\s+/g, ' ').trim() ?? null,
       nationality:
         newUserInfo.nationality?.toUpperCase().replace(/\s/g, '_') ?? null,
-      birth: formatDateToDash(newUserInfo.birth as string),
+      birth: newUserInfo.birth
+        ? formatDateToDash(newUserInfo.birth as string)
+        : null,
       phone_number: phoneNum,
       visa: newUserInfo.visa?.replace(/-/g, '_') ?? '',
     };

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -70,6 +70,44 @@ const InformationStep = ({
     setIsInvalid(false);
   }, [newUserInfo, phoneNum]);
 
+  // 사용자 정보 포맷팅을 위한 별도 함수
+  const formatUserInfoForSubmission = (
+    newUserInfo: UserInfo,
+    phoneNum: string,
+  ): UserInfo => {
+    return {
+      ...newUserInfo,
+      first_name:
+        newUserInfo.first_name &&
+        newUserInfo.first_name.replace(/\s+/g, ' ').trim(),
+      last_name:
+        newUserInfo.last_name &&
+        newUserInfo.last_name.replace(/\s+/g, ' ').trim(),
+      nationality:
+        newUserInfo.nationality === null
+          ? null
+          : newUserInfo.nationality.toUpperCase().replace(/\s/g, '_'),
+      birth: formatDateToDash(newUserInfo.birth as string),
+      phone_number: phoneNum,
+      visa:
+        newUserInfo.visa !== null ? newUserInfo.visa.replace(/-/g, '_') : '',
+    };
+  };
+
+  const handleNextClick = () => {
+    if (isInvalid) return;
+
+    const formattedUserInfo = formatUserInfoForSubmission(
+      newUserInfo,
+      formatPhoneNumber(phoneNum),
+    );
+
+    onNext({
+      ...userInfo,
+      user_info: formattedUserInfo,
+    });
+  };
+
   return (
     <div className="w-full flex flex-col gap-4">
       <div className="w-full flex flex-row items-center justify-between">
@@ -198,29 +236,7 @@ const InformationStep = ({
             fontColor={isInvalid ? '' : 'text-[#222]'}
             isBorder={false}
             title="Next"
-            onClick={
-              isInvalid
-                ? undefined
-                : () =>
-                    onNext({
-                      ...userInfo,
-                      user_info: {
-                        ...newUserInfo,
-                        nationality:
-                          newUserInfo.nationality === null
-                            ? null
-                            : newUserInfo.nationality
-                                .toUpperCase()
-                                .replace(/\s/g, '_'),
-                        birth: formatDateToDash(newUserInfo.birth as string),
-                        phone_number: formatPhoneNumber(phoneNum),
-                        visa:
-                          newUserInfo.visa !== null
-                            ? newUserInfo.visa.replace(/-/g, '_')
-                            : '',
-                      },
-                    })
-            }
+            onClick={handleNextClick}
           />
         </BottomButtonPanel>
       </div>

--- a/src/utils/information.ts
+++ b/src/utils/information.ts
@@ -1,24 +1,57 @@
-// Regular expression for first name validation
-// Allows 1-50 characters, only letters (no numbers or special characters)
-export const firstNameRegex = /^[A-Za-z가-힣]{1,50}$/;
+// 이름 유효성 검사 및 포맷팅 관련 유틸리티 함수들
+// 이름은 영문 대소문자, 한글만 허용하며, 공백도 허용
+// 연속된 공백은 하나의 공백으로 간주
+export const nameRegexWithSpaces = /^[A-Za-z가-힣]+(?: [A-Za-z가-힣]+)*$/;
 
-// Regular expression for last name validation
-// Allows 1-100 characters, only letters (no numbers or special characters)
-export const lastNameRegex = /^[A-Za-z가-힣]{1,50}$/;
+// 이름의 최대 길이
+export const MAX_NAME_LENGTH = 50;
 
-// Function to test if a string matches the first name criteria
-export const isValidFirstName = (name: string): boolean => {
-  return firstNameRegex.test(name);
+/**
+ * 공백을 포함한 이름에서 실제 문자 수를 계산하는 함수
+ * 연속된 공백은 하나의 공백으로 간주하여 계산
+ * @param name 사용자가 입력한 이름
+ * @returns 정규화된 공백을 포함한 문자 수
+ */
+export const countNormalizedNameLength = (name: string): number => {
+  // 연속된 공백을 하나의 공백으로 정규화
+  const normalizedName = name.replace(/\s+/g, ' ').trim();
+  return normalizedName.length;
 };
 
-// Function to test if a string matches the last name criteria
-export const isValidLastName = (name: string): boolean => {
-  return lastNameRegex.test(name);
+/**
+ * 이름 유효성 검사 함수
+ * 1. 공백이 허용됨 (연속된 공백은 하나로 간주)
+ * 2. 이름은 글자(영문, 한글)와 공백만 포함 가능
+ * 3. 정규화된 총 길이는 MAX_NAME_LENGTH(50자) 이하
+ * @param name 사용자가 입력한 이름
+ * @returns 유효성 검사 결과
+ */
+export const isValidName = (name: string): boolean => {
+  // 빈 문자열 체크
+  if (name.trim() === '') {
+    return false;
+  }
+
+  // 공백 정규화 후 길이 체크
+  const normalizedLength = countNormalizedNameLength(name);
+  if (normalizedLength > MAX_NAME_LENGTH) {
+    return false;
+  }
+
+  // 정규화된 이름 생성 (연속된 공백을 하나의 공백으로)
+  const normalizedName = name.replace(/\s+/g, ' ').trim();
+
+  return nameRegexWithSpaces.test(normalizedName);
 };
 
 // 이름 유효성 검사 함수
-export const isValidName = (name: string) =>
-  name.trim() !== '' && (isValidFirstName(name) || isValidLastName(name));
+export const isValidFirstName = (name: string): boolean => {
+  return isValidName(name);
+};
+
+export const isValidLastName = (name: string): boolean => {
+  return isValidName(name);
+};
 
 // 전화번호 유효성 검사 함수
 export const isValidPhoneNumber = (phone: {

--- a/src/utils/information.ts
+++ b/src/utils/information.ts
@@ -27,19 +27,13 @@ export const countNormalizedNameLength = (name: string): number => {
  * @returns 유효성 검사 결과
  */
 export const isValidName = (name: string): boolean => {
-  // 빈 문자열 체크
-  if (name.trim() === '') {
-    return false;
-  }
 
-  // 공백 정규화 후 길이 체크
-  const normalizedLength = countNormalizedNameLength(name);
+  const normalizedName = name.replace(/\s+/g, ' ').trim();
+
+  const normalizedLength = normalizedName.length;
   if (normalizedLength > MAX_NAME_LENGTH) {
     return false;
   }
-
-  // 정규화된 이름 생성 (연속된 공백을 하나의 공백으로)
-  const normalizedName = name.replace(/\s+/g, ' ').trim();
 
   return nameRegexWithSpaces.test(normalizedName);
 };


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #327 

## Work Description ✏️

- 회원 가입 중 이름, 성 입력 시 공백(띄어쓰기) 허용하도록 수정
- 사용자가 연속된 공백을 입력 시 1칸으로 간주하고 이름 길이 측정, 50자 이상이면 회원가입 불가능
- 연속된 공백을 입력했더라도 회원가입 시 1칸으로 변환해 가입

<img width="390" alt="스크린샷 2025-04-23 오후 8 06 36" src="https://github.com/user-attachments/assets/cb2644fe-ced8-4bd3-b4f0-3d6a7e1591b5" />

<img width="390" alt="스크린샷 2025-04-23 오후 8 06 36" src="https://github.com/user-attachments/assets/69cd5c04-d46d-497d-94db-35cbe372e888" />


## Uncompleted Tasks 😅


## To Reviewers 📢



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 이름 입력값의 유효성 검증 로직이 통합 및 개선되어, 영어, 한글, 공백(단어 사이) 입력을 지원하고 최대 길이(50자) 제한이 명확해졌습니다.
  - 이름 입력 시 불필요한 공백이 자동으로 정리되고, 일관된 형식으로 처리됩니다.
  - 사용자 정보 제출 전 포맷팅 로직이 별도 함수로 분리되어 코드 가독성과 유지보수성이 향상되었습니다.

- **Bug Fixes**
  - 이름 입력 시 여러 단어, 공백 및 길이 제한 관련 오류가 해결되었습니다.

- **Style**
  - "다음" 버튼 클릭 시 입력값 포맷팅 및 제출 로직이 간소화되어, 버튼 동작이 더욱 일관되고 안정적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->