### PR TITLE
🐛 fix: 유학생의 문서 생성 후 제출 전 고용주에게 동일한 ui 제공 #331

### DIFF
--- a/src/pages/Employer/WriteDocuments/ApplicantDocumentsDetailPage.tsx
+++ b/src/pages/Employer/WriteDocuments/ApplicantDocumentsDetailPage.tsx
@@ -46,7 +46,7 @@ const ApplicantDocumentsDetailPage = () => {
           />
           <div className="flex flex-col gap-2 p-4">
             {documentTypes.map((property, index) =>
-              data?.data[property] ? (
+              data?.data[property]?.status ? (
                 <DocumentCardDispenserEmployer
                   key={`${index}_${property}`}
                   documentInfo={data.data[property] as EmployDocumentInfo}


### PR DESCRIPTION
## Related issue 🛠

- closed #331 

## Work Description ✏️

- 유학생이 문서 생성 후 고용주에게 제출 전 고용주 측에서 문서 관리 ui가 없어지는 현상 해결

<img width="335" alt="스크린샷 2025-04-26 오후 7 17 40" src="https://github.com/user-attachments/assets/c2eca28a-4d9c-41f4-8f7d-f1daffa53f19" />
<img width="336" alt="스크린샷 2025-04-26 오후 9 29 57" src="https://github.com/user-attachments/assets/346db7c5-3ff4-48a1-9072-4c8a27efa7da" />


## Uncompleted Tasks 😅

## To Reviewers 📢
유학생이 문서를 생성하고 고용주에게 제출하지 않았을때는 아래와 같은 형식으로 반환되는데, id가 문서가 조회되지만 status가 `null` 로 반환되어 매칭되는 ui가 없어 생기는 문제였습니다.
`InfoCardLayout` 과 `DocumentCard` 를 렌더링하는 기준을 문서의 status로 변경해 해결했습니다.
```
(document_name): 
{id: 18, word_url: null, status: null, reason: null}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 문서 카드가 문서 데이터의 `status` 값이 있을 때만 표시되도록 개선되었습니다. 이제 상태가 없는 문서는 목록에 노출되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->