### PR TITLE
[fix/319] react-kakao-maps-sdk에 autoload=false 적용하기

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <script type="module" src="/src/main.tsx"></script>
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_APP_KAKAO_API_KEY%&libraries=services,clusterer"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_APP_KAKAO_API_KEY%&libraries=services,clusterer&autoload=false"
       defer
     ></script>
   </body>


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #319

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- react-kakao-maps-sdk를 불러오는 script에 autoload=false 적용하기

“렌더링 차단 리소스 제거”를 위해 script defer를 이용해서 최적화를 하려고 했었는데 `kakao.maps.LatLng is not a constructor` 라는 에러가 발생했습니다.. 

에러 발생 이유는 defer를 사용하여 SDK가 로드되기 전에 kakao.maps.LatLng()로 접근하려고 한 거여서 autoload=false를 통해 로드 전에 접근하지 않도록 하고 이후에 react-kakao-maps-sdk 라이브러리가 내부적으로 kakao.maps.load()를 호출해서 사진처럼 잘 나타납니다!

<img src="https://github.com/user-attachments/assets/46e98d19-06fb-42f7-9202-fb35716d9c81" width="300" />


## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
  - Kakao Maps SDK가 자동으로 로드되지 않도록 변경되었습니다. 이제 지도를 수동으로 초기화해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->