### PR TITLE
Feature/351 App Bar 스펙 수정

### DIFF
--- a/src/assets/icons/Home/SearchIcon.svg
+++ b/src/assets/icons/Home/SearchIcon.svg
@@ -1,0 +1,3 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 21L27 27M16 23C12.134 23 9 19.866 9 16C9 12.134 12.134 9 16 9C19.866 9 23 12.134 23 16C23 19.866 19.866 23 16 23Z" stroke="#5A5B63" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Home/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader.tsx
@@ -1,5 +1,6 @@
 import AlarmIcon from '@/assets/icons/Home/AlarmIcon.svg?react';
 import HeaderLogoIcon from '@/assets/icons/Home/HeaderLogoIcon.svg?react';
+import SearchIcon from '@/assets/icons/Home/SearchIcon.svg?react';
 import { useGetAlarms } from '@/hooks/api/useAlarm';
 import { useUserStore } from '@/store/user';
 import { AlarmItemType } from '@/types/api/alarm';
@@ -29,19 +30,34 @@ const HomeHeader = () => {
 
   return (
     <>
-      <header className="w-full h-[3.75rem] px-4 py-2 flex justify-between items-center border-b border-[#E2E5EB]">
-        <HeaderLogoIcon />
-        <button
-          className="w-[2rem] h-[2rem] flex justify-center items-center relative  rounded-[1.25rem]"
-          onClick={handleClickAlarm}
-        >
-          <AlarmIcon />
-          {/* 알람이 있을 때만 표시하기 */}
-          {isNotReadAlarms(data?.data?.notification_list) && (
-            <div className="absolute top-[0.2rem] right-[0.4rem] w-[0.438rem] h-[0.438rem] rounded-full bg-[#FF6F61]"></div>
-          )}
-        </button>
+      <header className="w-full h-[3.5rem] px-[0.625rem] flex justify-between items-center border-b border-[#E2E5EB]">
+        {/* 로고 영역 96x40 + 내부 여백 포함 */}
+        <div className="w-[6rem] h-[2.5rem] flex items-center justify-center">
+          <HeaderLogoIcon className="w-[5.375rem] h-[2rem]" />{' '}
+          {/* 86x32 로고 */}
+        </div>
+
+        {/* 아이콘 영역 */}
+        <div className="flex items-center gap-1">
+          {/* 검색 아이콘 예시 */}
+          <button className="w-[2.25rem] h-[2.25rem] flex justify-center items-center rounded-full">
+            <SearchIcon />
+          </button>
+
+          {/* 알림 아이콘 */}
+          <button
+            className="w-[2.25rem] h-[2.25rem] flex justify-center items-center relative rounded-full"
+            onClick={handleClickAlarm}
+          >
+            <AlarmIcon />
+            {/* 알람이 있을 때만 표시 */}
+            {isNotReadAlarms(data?.data?.notification_list) && (
+              <div className="absolute top-[0.2rem] right-[0.4rem] w-[0.438rem] h-[0.438rem] rounded-full bg-[#FF6F61]" />
+            )}
+          </button>
+        </div>
       </header>
+
       <LoginBottomSheet
         isShowBottomsheet={isOpenLoginBottomSheet}
         setIsShowBottomSheet={setIsOpenLoginBottomSheet}

--- a/src/components/Home/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader.tsx
@@ -39,7 +39,7 @@ const HomeHeader = () => {
 
         {/* 아이콘 영역 */}
         <div className="flex items-center gap-1">
-          {/* 검색 아이콘 예시 */}
+          {/* 검색 아이콘 */}
           <button className="w-[2.25rem] h-[2.25rem] flex justify-center items-center rounded-full">
             <SearchIcon />
           </button>


### PR DESCRIPTION
## Related issue 🛠

- closed #351 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 로고영역의 소수점을 없앰 -> 96 * 40
- 아이콘과 로고 간의 정렬맞춤을 위해 로고영역의 좌/상단 패딩을 아래와 같이 적용
  - App Bar 의 높이는 56px으로 고정
  - App Bar의 좌우 패딩은 10px으로 고정
  - 아이콘 영역은 36 * 36 이며, 각 아이콘 간 간격은 4px로 고정

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] Task1

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"
![image](https://github.com/user-attachments/assets/98697ff5-109c-4149-93cd-d6c2f9475a2e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
  - 홈 헤더의 높이와 패딩이 조정되어 전체 레이아웃이 더 컴팩트해졌습니다.
  - 로고가 고정된 크기의 컨테이너에 배치되고, 크기가 조정되어 일관성이 향상되었습니다.
  - 알람 버튼과 새로운 검색 버튼이 동일한 크기와 스타일로 나란히 배치되었습니다.
  - 알람 버튼의 패딩이 제거되고, 아이콘 버튼들의 크기와 모양이 통일되었습니다.
- **New Features**
  - 홈 헤더에 검색 버튼이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->