### PR TITLE
[fix/343] 마감된 공고인 경우 closed로 표기

### DIFF
--- a/src/components/Common/JobPostingCard.tsx
+++ b/src/components/Common/JobPostingCard.tsx
@@ -48,14 +48,21 @@ const CardDeadLineTag = () => {
   const { recruitment_dead_line } = useCard();
   const { account_type } = useUserStore();
 
-  const formattedRecruitmentDeadLine =
-    recruitment_dead_line === '상시모집'
-      ? postTranslation.dDay[isEmployerByAccountType(account_type)]
-      : `${calculateDays(recruitment_dead_line)}${postTranslation.daysLeft[isEmployerByAccountType(account_type)]}`;
+  const formatRecruitmentDeadLine = () => {
+    if (recruitment_dead_line === '상시모집')
+      return postTranslation.dDay[isEmployerByAccountType(account_type)];
+
+    const leftDays = calculateDays(recruitment_dead_line);
+
+    if (leftDays < 0)
+      return postTranslation.closed[isEmployerByAccountType(account_type)];
+    else
+      return `${leftDays}${postTranslation.daysLeft[isEmployerByAccountType(account_type)]}`;
+  };
 
   return (
     <Tag
-      value={formattedRecruitmentDeadLine}
+      value={formatRecruitmentDeadLine()}
       padding="px-1 py-[0.188rem]"
       isRounded={false}
       hasCheckIcon={false}

--- a/src/constants/translation.ts
+++ b/src/constants/translation.ts
@@ -547,6 +547,10 @@ export const postTranslation = {
     ko: '일 남음',
     en: 'days left',
   },
+  closed: {
+    ko: '모집 마감',
+    en: 'closed',
+  },
 };
 
 export const careerDetailTranslation = {


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #343

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 마감된 공고인 경우 -12 days left로 음수로 나타나는 이슈에 대해 closed 문구를 보여주도록 처리했습니다.

<img src="https://github.com/user-attachments/assets/e4359d70-56a3-4e7b-ac58-48db43986e74" width="300" />


## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 모집 마감일 표시가 개선되어, 마감일이 지난 경우 "모집 마감"으로 명확하게 안내됩니다.
- **문서화**
  - "모집 마감"에 대한 한글 및 영어 번역이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->