### PR TITLE
Feature/369 인재 이력서 조회 페이지 구현

### DIFF
--- a/src/__tests__/mocks/resume.mock.ts
+++ b/src/__tests__/mocks/resume.mock.ts
@@ -62,3 +62,11 @@ export const createMockResumeData = () => ({
     },
   },
 });
+
+// 공개 설정 응답 모킹을 위한 함수 추가
+export const createResumePublicResponse = (isPublic: boolean) => ({
+  success: true,
+  data: {
+    is_public: isPublic,
+  },
+});

--- a/src/api/resumes.ts
+++ b/src/api/resumes.ts
@@ -185,6 +185,14 @@ export const patchResumePublic = async (data: { is_public: boolean }) => {
   return response.data;
 };
 
+// 7.25 (고용주) 이력서 상세 조회하기
+export const getResumeDetail = async (id: string) => {
+  const response = await api.get(
+    `/owners/resumes/${id}/details`,
+  );
+  return response.data;
+};
+
 // 9.1 (유학생) 학교 검색하기
 export const getSearchSchools = async ({
   search,

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -116,7 +116,7 @@ const InformationStep = ({
           content={signInputTranclation.infoStepContent[isEmployer(pathname)]}
         />
       </div>
-      <div className="w-full mx-auto mb-[7rem]">
+      <div className="w-full mx-auto mb-[7rem] px-4">
         <div className="w-full flex flex-col gap-[1rem]">
           {/* 이름 작성 */}
           <InputLayout title="First Name" isEssential={true}>

--- a/src/components/Information/LanguageStep.tsx
+++ b/src/components/Information/LanguageStep.tsx
@@ -27,7 +27,7 @@ const LanguageStep = ({ onNext }: LanguageStepProps) => {
           }
         />
       </div>
-      <div className="w-full flex flex-col gap-[1.125rem]">
+      <div className="w-full flex flex-col gap-[1.125rem] px-4">
         {/* 언어 선택 작성 */}
         <InputLayout title="Language" isEssential={true}>
           <Dropdown

--- a/src/components/PostApply/PostApplyResume.tsx
+++ b/src/components/PostApply/PostApplyResume.tsx
@@ -1,7 +1,5 @@
-import { useGetApplicantResume, useGetResume } from '@/hooks/api/useResume';
 import { useUserStore } from '@/store/user';
 import { UserType } from '@/constants/user';
-import { useCurrentApplicantIdStore } from '@/store/url';
 import { LoadingItem } from '@/components/Common/LoadingItem';
 import { profileTranslation } from '@/constants/translation';
 import { isEmployer } from '@/utils/signup';
@@ -11,28 +9,13 @@ import { ManageResumeType } from '@/constants/manageResume';
 import MypageCard from '@/components/ManageResume/MypageCard';
 import ResumeProfileCard from '@/components/ManageResume/ResumeProfileCard';
 import { useCallback } from 'react';
+import useResumeData from '@/hooks/useResumeData';
 
 const PostApplyResume = () => {
-  const { pathname } = useLocation();
   const navigate = useNavigate();
-
-  const { currentApplicantId } = useCurrentApplicantIdStore();
+  const { pathname } = useLocation();
   const { account_type } = useUserStore();
-
-  const { data: userData, isPending: userDataPending } = useGetResume(
-    account_type === UserType.USER,
-  );
-  const { data: ownerData, isPending: ownerDataPending } =
-    useGetApplicantResume(
-      Number(currentApplicantId),
-      !isNaN(Number(currentApplicantId)) && account_type === UserType.OWNER
-        ? true
-        : false,
-    );
-
-  const data = account_type === UserType.OWNER ? ownerData : userData;
-  const isPending =
-    account_type === UserType.OWNER ? ownerDataPending : userDataPending;
+  const { data, isPending } = useResumeData();
 
   // 재사용 가능한 네비게이션 핸들러
   const navigateToSection = useCallback(

--- a/src/hooks/api/useResume.ts
+++ b/src/hooks/api/useResume.ts
@@ -6,6 +6,7 @@ import {
   getApplicantResume,
   getEducation,
   getResume,
+  getResumeDetail,
   getSearchSchools,
   getWorkExperience,
   getWorkPreference,
@@ -290,6 +291,15 @@ export const usePatchResumePublic = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['resume'] });
     },
+  });
+};
+
+// 7.25 (고용주) 이력서 상세 조회하기
+export const useGetResumeDetail = (id: string, isEnabled: boolean) => {
+  return useQuery({
+    queryKey: ['resumeDetail', id],
+    queryFn: () => getResumeDetail(id),
+    enabled: isEnabled,
   });
 };
 

--- a/src/hooks/useResumeData.ts
+++ b/src/hooks/useResumeData.ts
@@ -1,0 +1,80 @@
+import { UserType } from '@/constants/user';
+import { useCurrentApplicantIdStore } from '@/store/url';
+import { useUserStore } from '@/store/user';
+import { useLocation, useParams } from 'react-router-dom';
+import {
+  useGetApplicantResume,
+  useGetResume,
+  useGetResumeDetail,
+} from './api/useResume';
+
+const useResumeData = () => {
+  const { pathname } = useLocation();
+  const { id } = useParams();
+
+  const { currentApplicantId } = useCurrentApplicantIdStore();
+  const { account_type } = useUserStore();
+
+  const getDataSourceType = ():
+    | 'employerSearch'
+    | 'ownerApplicant'
+    | 'user' => {
+    if (pathname === '/employer/search' && id) {
+      return 'employerSearch';
+    }
+
+    if (account_type === UserType.OWNER) {
+      return 'ownerApplicant';
+    }
+
+    return 'user';
+  };
+
+  const dataSourceType = getDataSourceType();
+
+  const shouldFetchUserData = dataSourceType === 'user';
+  const shouldFetchOwnerData =
+    dataSourceType === 'ownerApplicant' && !isNaN(Number(currentApplicantId));
+  const shouldFetchOwnerResumeData = dataSourceType === 'employerSearch';
+
+  // 데이터 페칭 훅들
+  const { data: userData, isPending: userDataPending } =
+    useGetResume(shouldFetchUserData);
+
+  const { data: ownerData, isPending: ownerDataPending } =
+    useGetApplicantResume(Number(currentApplicantId), shouldFetchOwnerData);
+
+  const { data: ownerResumeData, isPending: ownerResumeDataPending } =
+    useGetResumeDetail(id ?? '', shouldFetchOwnerResumeData);
+
+  const getActiveData = () => {
+    switch (dataSourceType) {
+      case 'employerSearch':
+        return {
+          data: ownerResumeData,
+          isPending: ownerResumeDataPending,
+        };
+      case 'ownerApplicant':
+        return {
+          data: ownerData,
+          isPending: ownerDataPending,
+        };
+      case 'user':
+      default:
+        return {
+          data: userData,
+          isPending: userDataPending,
+        };
+    }
+  };
+
+  const { data, isPending } = getActiveData();
+
+  return {
+    data,
+    isPending,
+    dataSourceType,
+  };
+};
+
+export default useResumeData;

--- a/src/pages/Information/InformationPage.tsx
+++ b/src/pages/Information/InformationPage.tsx
@@ -105,7 +105,7 @@ const InformationPage = () => {
               }`}
             />
           </div>
-          <div className="w-full flex justify-center px-4 pt-4">
+          <div className="w-full flex justify-center pt-4">
             {currentStep === 1 && (
               <InformationStep userInfo={userInfo} onNext={handleNext} />
             )}

--- a/src/pages/Resume/EmploySearchDetailPage.test.tsx
+++ b/src/pages/Resume/EmploySearchDetailPage.test.tsx
@@ -2,9 +2,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import EmploySearchDetailPage from './EmploySearchDetailPage';
-import { QueryClient, QueryClientProvider, UseQueryResult } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+  UseQueryResult,
+} from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { useGetApplicantResume } from '@/hooks/api/useResume';
+import { ApplicantResumeResponse } from '@/types/api/resumes';
 
 // Mock React Router
 const mockNavigateBack = vi.fn();
@@ -102,7 +107,7 @@ describe('EmploySearchDetailPage', () => {
       },
       isLoading: false,
       error: null,
-    } as UseQueryResult<ApplicantResume, Error>);
+    } as UseQueryResult<ApplicantResumeResponse, Error>);
   });
 
   describe('렌더링', () => {
@@ -156,7 +161,7 @@ describe('EmploySearchDetailPage', () => {
         },
         isLoading: false,
         error: null,
-      } as any);
+      } as UseQueryResult<ApplicantResumeResponse, Error>);
 
       render(<EmploySearchDetailPage />, { wrapper: createWrapper() });
 
@@ -189,7 +194,7 @@ describe('EmploySearchDetailPage', () => {
         data: null,
         isLoading: false,
         error: null,
-      } as any);
+      } as UseQueryResult<ApplicantResumeResponse | null, Error>);
 
       render(<EmploySearchDetailPage />, { wrapper: createWrapper() });
 
@@ -209,7 +214,7 @@ describe('EmploySearchDetailPage', () => {
         },
         isLoading: false,
         error: null,
-      } as any);
+      } as UseQueryResult<ApplicantResumeResponse, Error>);
 
       render(<EmploySearchDetailPage />, { wrapper: createWrapper() });
 

--- a/src/types/api/resumes.ts
+++ b/src/types/api/resumes.ts
@@ -69,3 +69,9 @@ export type UserResumeDetailResponse = {
   languages: LanguageListType;
   is_public: boolean;
 };
+
+// 고용주가 인재 이력서 조회시 사용하는 응답 타입
+export type ApplicantResumeResponse = {
+  is_scraped: boolean;
+  data: UserResumeDetailResponse;
+};


### PR DESCRIPTION
## Related issue 🛠

#369 

## Work Description ✏️

- 7.25 api 추가 및 적용
- PageTitle 컴포넌트 변경으로 인한 일부 페이지 디자인 깨짐 수정

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이력서 상세 정보를 조회할 수 있는 기능이 추가되었습니다.

- **리팩터**
  - 이력서 데이터 조회 로직이 하나의 커스텀 훅으로 통합되어 코드가 간결해졌습니다.

- **스타일**
  - 일부 입력 폼과 언어 선택 영역에 가로 패딩이 추가되었으며, 정보 입력 페이지의 패딩이 조정되었습니다.

- **테스트**
  - 테스트 코드의 타입 안정성이 개선되었습니다.

- **타입**
  - 이력서 응답 관련 새로운 타입이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->