### PR TITLE
Fix/404 이력서/프로필 수정 qa 피드백 적용

### DIFF
--- a/src/components/Common/InfoCardLayout.tsx
+++ b/src/components/Common/InfoCardLayout.tsx
@@ -14,7 +14,7 @@ const InfoCardLayout = ({
   rightTopElement,
 }: InfoCardLayoutProps) => {
   return (
-    <section className="w-full py-6 px-4 bg-white rounded-lg">
+    <section className="w-full py-6 px-4 bg-white">
       <div className="flex items-center">
         <div className="flex items-center gap-2">
           {icon && <div>{icon}</div>}

--- a/src/components/Common/InfoCardLayout.tsx
+++ b/src/components/Common/InfoCardLayout.tsx
@@ -14,18 +14,18 @@ const InfoCardLayout = ({
   rightTopElement,
 }: InfoCardLayoutProps) => {
   return (
-    <section className="w-full py-6 px-4 bg-white">
+    <section className="w-full py-6 px-4 bg-surface-base">
       <div className="flex items-center">
         <div className="flex items-center gap-2">
           {icon && <div>{icon}</div>}
-          <h3 className="heading-18-semibold text-[#191919]">{title}</h3>
+          <h3 className="heading-18-semibold text-text-strong">{title}</h3>
         </div>
         {rightTopElement && (
           <div className="ml-auto self-end">{rightTopElement}</div>
         )}
       </div>
       {children && (
-        <div className="mt-3 pt-3 border-t border-[#F8F8F8]">{children}</div>
+        <div className="mt-3 pt-3 border-t border-surface-secondary">{children}</div>
       )}
     </section>
   );

--- a/src/components/Home/LanguageBottomSheet.tsx
+++ b/src/components/Home/LanguageBottomSheet.tsx
@@ -98,7 +98,7 @@ const LanguageBottomSheet = ({
     <BottomSheetLayout
       isShowBottomsheet={isShowBottomsheet}
       setIsShowBottomSheet={setIsShowBottomSheet}
-      isAvailableHidden={false}
+      isAvailableHidden={true}
     >
       {/* Google Translate 위젯을 위한 숨겨진 div */}
       <div id="google_translate_element" style={{ display: 'none' }}></div>

--- a/src/components/Language/LanguageCard.tsx
+++ b/src/components/Language/LanguageCard.tsx
@@ -79,6 +79,7 @@ const LanguageCard = ({
         <ResumeDeleteModal
           onEditButton={openLevelBottomSheet}
           onDeleteButton={handleDelete}
+          setIsShowBottomSheet={() => setModalOpen(false)}
         />
       )}
       {/* 언어 레벨 선택 바텀 시트 */}

--- a/src/components/ManageResume/EducationDetail.tsx
+++ b/src/components/ManageResume/EducationDetail.tsx
@@ -39,6 +39,7 @@ const EducationDetail = ({ data }: EducationDetailProps) => {
         <ResumeDeleteModal
           onEditButton={() => navigate(`/resume/education/${selectedId}`)}
           onDeleteButton={handleDelete}
+          setIsShowBottomSheet={() => setModalOpen(false)}
         />
       )}
       <div className="flex flex-col gap-2">

--- a/src/components/ManageResume/ResumeDeleteModal.tsx
+++ b/src/components/ManageResume/ResumeDeleteModal.tsx
@@ -14,13 +14,13 @@ const ResumeDeleteModal = ({
 
   return (
     <BottomSheetLayout
-      isAvailableHidden={false}
+      isAvailableHidden={true}
       isShowBottomsheet={true}
       isFixedBackground={true}
     >
       <div className="w-full flex flex-col bg-white rounded-[1.125rem] overflow-hidden">
         <div>
-          <h1 className="pb-3 heading-18-semibold text-text-strong">
+          <h1 className="py-3 heading-18-semibold text-text-strong">
             Are you sure you want to delete?
           </h1>
         </div>
@@ -29,14 +29,14 @@ const ResumeDeleteModal = ({
             className="py-3 w-full flex justify-start items-center body-16-regular text-text-strong"
             onClick={onEditButton}
           >
-            수정하기
+            Edit
           </button>
           {onDeleteButton && (
             <button
               className="py-3 w-full flex justify-start items-start body-16-regular text-text-error"
               onClick={onDeleteButton}
             >
-              삭제하기
+              Delete
             </button>
           )}
         </div>

--- a/src/components/ManageResume/ResumeDeleteModal.tsx
+++ b/src/components/ManageResume/ResumeDeleteModal.tsx
@@ -4,11 +4,13 @@ import useBodyScrollLock from '@/hooks/useBodyScrollLock';
 type ResumeDeleteModalProps = {
   onEditButton: () => void;
   onDeleteButton?: () => void;
+  setIsShowBottomSheet?: (isShow: boolean) => void;
 };
 
 const ResumeDeleteModal = ({
   onEditButton,
   onDeleteButton,
+  setIsShowBottomSheet = () => {},
 }: ResumeDeleteModalProps) => {
   useBodyScrollLock(true);
 
@@ -17,6 +19,7 @@ const ResumeDeleteModal = ({
       isAvailableHidden={true}
       isShowBottomsheet={true}
       isFixedBackground={true}
+      setIsShowBottomSheet={setIsShowBottomSheet}
     >
       <div className="w-full flex flex-col bg-white rounded-[1.125rem] overflow-hidden">
         <div>

--- a/src/components/ManageResume/WorkExperienceDetail.tsx
+++ b/src/components/ManageResume/WorkExperienceDetail.tsx
@@ -38,6 +38,7 @@ const WorkExperienceDetail = ({ data }: WorkExperienceDetailProps) => {
         <ResumeDeleteModal
           onEditButton={() => navigate(`/resume/work-experience/edit/${selectedId}`)}
           onDeleteButton={handleDelete}
+          setIsShowBottomSheet={() => setModalOpen(false)}
         />
       )}
       <div className="flex flex-col gap-2">

--- a/src/components/PostSearchFilter/PostSearchFilterBottomSheet.tsx
+++ b/src/components/PostSearchFilter/PostSearchFilterBottomSheet.tsx
@@ -30,7 +30,7 @@ const PostSearchFilterBottomSheet = ({
 
   return (
     <BottomSheetLayout
-      isAvailableHidden={true}
+      isAvailableHidden={false}
       isShowBottomsheet={true}
       isFixedBackground={false}
     >

--- a/src/components/PostSearchFilter/PostSearchFilterBottomSheet.tsx
+++ b/src/components/PostSearchFilter/PostSearchFilterBottomSheet.tsx
@@ -30,7 +30,7 @@ const PostSearchFilterBottomSheet = ({
 
   return (
     <BottomSheetLayout
-      isAvailableHidden={false}
+      isAvailableHidden={true}
       isShowBottomsheet={true}
       isFixedBackground={false}
     >

--- a/src/utils/editProfileData.ts
+++ b/src/utils/editProfileData.ts
@@ -7,6 +7,7 @@ import {
 } from '@/types/api/profile';
 import { isValidPhoneNumber } from './information';
 import { initialAddress } from '../types/api/users';
+import { getNationalityEnumFromEn } from './resume';
 
 // GET 데이터를 PATCH 요청 데이터로 변환
 export const changeValidData = (
@@ -40,11 +41,7 @@ export const transformToProfileRequest = (
     birth: data.birth ? data.birth.replace(/-/g, '/') : '',
     gender:
       data.gender.charAt(0).toUpperCase() + data.gender.slice(1).toLowerCase(),
-    nationality: data.nationality
-      .toLowerCase()
-      .split('_')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' '),
+    nationality: getNationalityEnumFromEn(data.nationality) as NationalityType,
     visa: data.visa.replace(/_/g, '-'),
     phone_number: data.phone_number,
     is_profile_img_changed: false,


### PR DESCRIPTION
## Related issue 🛠

- closed #404 

## Work Description ✏️
- 25.06.17 이력서/프로필 수정 관련 qa 사항 피드백을 적용한 pr입니다.

- [x] 편집 모달 스와이프로 닫기 지원
- [x] 모달 header padding 요구사항대로 변경
- [x] 사용자 유형에 맞는 문구로 변경
- [x] 프로필 수정 시 국적 자동 입력 누락 수정
- [x] 이력서 조회 페이지 항목 카드별 border radius 제거

<img width="320px" src="https://github.com/user-attachments/assets/2d063e75-ce71-4f02-be46-369c0ef269d8" />
<img width="320px" src="https://github.com/user-attachments/assets/88e3afc8-3809-4161-b282-b964573692ce" />

<img width="320px" alt="스크린샷 2025-06-18 오전 2 24 12" src="https://github.com/user-attachments/assets/d42a74b5-e553-494f-af49-94abbdd0cc56" />


- 작업 내용

## Uncompleted Tasks 😅

N/A

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 카드 컨테이너의 배경색과 텍스트, 경계선 색상이 시맨틱 CSS 클래스로 변경되었습니다.
  - 카드 컨테이너의 모서리 둥글기 스타일이 제거되었습니다.
  - 모달 헤딩의 패딩이 하단에서 상하로 변경되었습니다.
  - 모달 내 버튼 텍스트가 한글에서 영어("Edit", "Delete")로 변경되었습니다.

- **버그 수정**
  - 모달 닫기 동작이 개선되어, 여러 위치에서 모달을 정상적으로 닫을 수 있게 되었습니다.

- **기능 개선**
  - 하단 시트의 숨김 동작이 일부 화면에서 변경되었습니다.
  - 프로필 요청 시 국적 데이터 변환 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->