### PR TITLE
[Feat/403] 커리어 상세조회에서 description 영역에 string -> html을 보여주도록 수정

### DIFF
--- a/src/components/Information/PolicyViewer.tsx
+++ b/src/components/Information/PolicyViewer.tsx
@@ -1,4 +1,5 @@
-import BaseHeader from '../Common/Header/BaseHeader';
+import { IFRAME_STYLE_TAG } from '@/constants/iframe';
+import BaseHeader from '@/components/Common/Header/BaseHeader';
 
 const PolicyViewer = ({
   content,
@@ -11,30 +12,7 @@ const PolicyViewer = ({
   const renderWithIframe = () => {
     const responsiveContent = content.replace(
       '</head>',
-      `<style>
-        :root {
-          /* 기본 폰트 크기 설정 */
-          font-size: calc(12px + 0.4vw);
-        }
-        
-        /* 디바이스 크기별 세부 조정 */
-        @media screen and (max-width: 320px) {
-          :root { font-size: 9px; }
-        }
-        @media screen and (min-width: 768px) {
-          :root { font-size: 16px; }
-        }
-        @media screen and (min-width: 1024px) {
-          :root { font-size: 18px; }
-        }
-  
-        /* 컨텐츠별 상대적 크기 설정 */
-        body { font-size: 1rem; }
-        .version-info { font-size: 0.875rem; }
-        h1 { font-size: 1.5rem; }
-        h2 { font-size: 1.25rem; }
-        .box { font-size: 1rem; }
-      </style>
+      `${IFRAME_STYLE_TAG}
       </head>`,
     );
 

--- a/src/components/PostDetail/CareerDetailContent.tsx
+++ b/src/components/PostDetail/CareerDetailContent.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CareerDetailContentMenu } from '@/constants/postDetail';
 import {
   careerDetailTranslation,
@@ -10,6 +10,7 @@ import { EducationLevelInfo } from '@/constants/post';
 import { EducationLevel } from '@/types/postCreate/postCreate';
 import { UserType } from '@/constants/user';
 import { CareerDetailItemType } from '@/types/api/career';
+import { IFRAME_STYLE_TAG } from '@/constants/iframe';
 
 const MenuTab = ({
   isSelected,
@@ -113,34 +114,88 @@ const DescriptionSection = ({
   details?: string;
   isEmployer: 'ko' | 'en';
 }) => {
-  const [showDetailOverview, setShowDetailOverview] = useState<boolean>(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = useState<number>(0); // iframe 하위 컨텐츠 높이
 
-  const shouldTruncate = details && details.length > 255;
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        event.data?.type === 'setHeight' &&
+        typeof event.data.height === 'number'
+      ) {
+        setIframeHeight(event.data.height);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
 
-  const displayText =
-    shouldTruncate && !showDetailOverview
-      ? `${details.slice(0, 255)}...`
-      : details;
+  // iframe 사용
+  const renderWithIframe = useCallback(() => {
+    if (!details) return <></>;
+
+    const responsiveContent = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="UTF-8" />
+          ${IFRAME_STYLE_TAG}
+        </head>
+        <body>
+        <div>${details}</div>
+        <script>
+          // iframe 내부에서 부모(React)에게 자신의 높이를 알려주는 함수
+          function sendHeight() {
+          const content = document.documentElement
+          if (!content) return;
+
+          // 브라우저가 렌더링을 마친 다음 실행
+          requestAnimationFrame(() => {
+              const height = Math.max(
+                content.scrollHeight,
+                content.offsetHeight
+              );
+              window.parent.postMessage({ type: 'setHeight', height }, '*');
+            });
+          }
+
+          window.addEventListener('load', sendHeight);
+          window.addEventListener('DOMContentLoaded', sendHeight);
+
+          // 콘텐츠가 동적으로 변경되는 경우를 감지하기 위해 MutationObserver 사용
+          const observer = new MutationObserver(() => {
+            sendHeight();
+          });
+
+          // 관찰 대상: body 내부의 모든 자식 요소 변화 감지
+          observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+          });
+        </script>
+        </body>
+      </html>
+    `;
+
+    return (
+      <iframe
+        ref={iframeRef}
+        className="w-full border-0"
+        srcDoc={responsiveContent}
+        title="HTML Content"
+        sandbox="allow-scripts"
+        style={{ height: `${iframeHeight}px` }}
+      />
+    );
+  }, [details, iframeHeight]);
 
   return (
     <article className="w-full px-4 py-6 bg-surface-base">
       <h3 className="pb-5 heading-18-semibold text-text-strong">
         {careerDetailTranslation.description[isEmployer]}
       </h3>
-      <div className="flex flex-col gap-3 w-full">
-        <p className="text-text-strong body-14-regular whitespace-pre-wrap break-all">
-          {displayText}
-        </p>
-
-        {shouldTruncate && !showDetailOverview && (
-          <button
-            onClick={() => setShowDetailOverview(true)}
-            className="w-full py-3 px-[0.625rem] border border-border-disabled rounded-[0.625rem]"
-          >
-            {postTranslation.seeMore[isEmployer]}
-          </button>
-        )}
-      </div>
+      <div className="w-full">{renderWithIframe()}</div>
     </article>
   );
 };

--- a/src/constants/iframe.ts
+++ b/src/constants/iframe.ts
@@ -1,0 +1,25 @@
+export const IFRAME_STYLE_TAG = `
+      <style>
+        :root {
+          /* 기본 폰트 크기 설정 */
+          font-size: calc(12px + 0.4vw);
+        }
+        
+        /* 디바이스 크기별 세부 조정 */
+        @media screen and (max-width: 320px) {
+          :root { font-size: 9px; }
+        }
+        @media screen and (min-width: 768px) {
+          :root { font-size: 16px; }
+        }
+        @media screen and (min-width: 1024px) {
+          :root { font-size: 18px; }
+        }
+  
+        /* 컨텐츠별 상대적 크기 설정 */
+        body { font-size: 1rem; }
+        .version-info { font-size: 0.875rem; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.25rem; }
+        .box { font-size: 1rem; }
+      </style>`;

--- a/src/pages/Home/HomeBannerPage.tsx
+++ b/src/pages/Home/HomeBannerPage.tsx
@@ -1,5 +1,6 @@
 import BaseHeader from '@/components/Common/Header/BaseHeader';
 import LoadingPostItem from '@/components/Common/LoadingPostItem';
+import { IFRAME_STYLE_TAG } from '@/constants/iframe';
 import {
   useGetGuestBannerDetail,
   useGetUserBannerDetail,
@@ -32,30 +33,7 @@ const HomeBannerPage = () => {
 
     const responsiveContent = bannerData.data.content.replace(
       '</head>',
-      `<style>
-        :root {
-          /* 기본 폰트 크기 설정 */
-          font-size: calc(12px + 0.4vw);
-        }
-        
-        /* 디바이스 크기별 세부 조정 */
-        @media screen and (max-width: 320px) {
-          :root { font-size: 9px; }
-        }
-        @media screen and (min-width: 768px) {
-          :root { font-size: 16px; }
-        }
-        @media screen and (min-width: 1024px) {
-          :root { font-size: 18px; }
-        }
-  
-        /* 컨텐츠별 상대적 크기 설정 */
-        body { font-size: 1rem; }
-        .version-info { font-size: 0.875rem; }
-        h1 { font-size: 1.5rem; }
-        h2 { font-size: 1.25rem; }
-        .box { font-size: 1rem; }
-      </style>
+      `${IFRAME_STYLE_TAG}
       </head>`,
     );
 


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #403

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 커리어 상세조회에서 description 영역에 string -> html을 보여주도록 수정 (이때 <iframe/>이 하위 요소만큼의 Height를 가질 수 있도록 <script> 추가)


https://github.com/user-attachments/assets/a8a67540-c92c-44a9-ab08-518ac23bddcf



## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 여러 컴포넌트에서 iframe 내 스타일을 중앙에서 관리하도록 개선하였습니다.
	- 배너 및 상세 설명 영역의 콘텐츠가 iframe을 통해 표시되며, 동적으로 높이가 조정되어 스크롤 없이 자연스럽게 보여집니다.
	- 기존의 텍스트 자르기 및 "더보기" 버튼 대신 iframe 기반의 콘텐츠 표시로 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->