### PR TITLE
Fix/407 google translate 번역 무한 로딩 현상 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,8 @@
     <title>Giggle</title>
     <style>
       /* Google 번역 배너 컨테이너 div 숨기기 */
-      body > div.skiptranslate {
+      body > div.skiptranslate,
+      svg.VIpgJd-ZVi9od-aZ2wEe {
         display: none !important;
       }
       html,

--- a/index.html
+++ b/index.html
@@ -25,7 +25,10 @@
     <style>
       /* Google 번역 배너 컨테이너 div 숨기기 */
       body > div.skiptranslate,
-      svg.VIpgJd-ZVi9od-aZ2wEe {
+      svg.VIpgJd-ZVi9od-aZ2wEe,
+      div.VIpgJd-ZVi9od-aZ2wEe-OiiCO,
+      div.VIpgJd-ZVi9od-aZ2wEe-OiiCO-ti6hGc,
+      #goog-gt-tt {
         display: none !important;
       }
       html,

--- a/index.html
+++ b/index.html
@@ -22,21 +22,6 @@
       gtag('config', 'G-BEM3WCV14C');
     </script>
     <title>Giggle</title>
-    <style>
-      /* Google 번역 배너 컨테이너 div 숨기기 */
-      body > div.skiptranslate,
-      svg.VIpgJd-ZVi9od-aZ2wEe,
-      div.VIpgJd-ZVi9od-aZ2wEe-OiiCO,
-      div.VIpgJd-ZVi9od-aZ2wEe-OiiCO-ti6hGc,
-      #goog-gt-tt {
-        display: none !important;
-      }
-      html,
-      body {
-        top: 0px !important;
-        margin-top: 0px !important;
-      }
-    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Home/LanguageBottomSheet.tsx
+++ b/src/components/Home/LanguageBottomSheet.tsx
@@ -1,6 +1,11 @@
 import { Dispatch, SetStateAction, useState, useEffect } from 'react';
 import BottomSheetLayout from '../Common/BottomSheetLayout';
-import { changeLanguage, getCurrentLanguage } from '@/utils/translate';
+import {
+  changeLanguage,
+  getCurrentLanguage,
+  revertToOriginal,
+  setTranslateElementInstance,
+} from '@/utils/translate';
 import Icon from '@/components/Common/Icon';
 import BottomSheetCheckIcon from '@/assets/icons/BottomSheetCheckIcon.svg?react';
 
@@ -15,6 +20,7 @@ interface Language {
 }
 
 const LANGUAGES: Language[] = [
+  { code: 'none', name: '없음' },
   { code: 'ko', name: '한국어' },
   { code: 'en', name: 'English' },
   { code: 'ja', name: '日本語' },
@@ -32,6 +38,32 @@ const LanguageBottomSheet = ({
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
 
   useEffect(() => {
+    // Google Translate의 기본 UI(배너, 툴팁)를 숨기는 스타일을 주입합니다.
+    // 번역 중 간헐적으로 나타나는 UI가 화면을 가리는 문제를 해결합니다.
+    const style = document.createElement('style');
+    style.id = 'google-translate-override';
+    style.innerHTML = `
+      .goog-te-banner-frame.skiptranslate {
+          display: none !important;
+      }
+      body {
+          top: 0px !important;
+      }
+      #goog-gt-tt {
+        display: none !important;
+      }
+    `;
+    document.head.appendChild(style);
+
+    return () => {
+      const styleElement = document.getElementById('google-translate-override');
+      if (styleElement) {
+        document.head.removeChild(styleElement);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     // 스크립트가 이미 주입되었거나, BottomSheet가 보이지 않으면 실행하지 않음
     if (isInitialized || !isShowBottomsheet) return;
 
@@ -43,13 +75,14 @@ const LanguageBottomSheet = ({
 
     window.googleTranslateElementInit = () => {
       if (window.google) {
-        new window.google.translate.TranslateElement(
+        const instance = new window.google.translate.TranslateElement(
           {
             pageLanguage: 'ko',
             autoDisplay: false,
           },
           'google_translate_element',
         );
+        setTranslateElementInstance(instance);
       }
       // 초기화 완료 후 현재 언어 설정
       setCurrentLanguage(getCurrentLanguage());
@@ -76,8 +109,24 @@ const LanguageBottomSheet = ({
   }, [isShowBottomsheet, isInitialized]);
 
   const handleLanguageClick = async (langCode: string) => {
-    if (langCode === currentLanguage || isChanging) {
-      if (langCode === currentLanguage) setIsShowBottomSheet(false);
+    if (isChanging) return;
+
+    if (langCode === 'none') {
+      setIsChanging(true);
+      try {
+        await revertToOriginal();
+        setCurrentLanguage('ko');
+        setIsShowBottomSheet(false);
+      } catch (error) {
+        console.error('언어 복원에 실패했습니다.', error);
+      } finally {
+        setIsChanging(false);
+      }
+      return;
+    }
+
+    if (langCode === currentLanguage) {
+      setIsShowBottomSheet(false);
       return;
     }
 

--- a/src/components/Home/LanguageBottomSheet.tsx
+++ b/src/components/Home/LanguageBottomSheet.tsx
@@ -46,9 +46,15 @@ const LanguageBottomSheet = ({
       .goog-te-banner-frame.skiptranslate {
           display: none !important;
       }
+      html,
       body {
-          top: 0px !important;
+        top: 0px !important;
+        margin-top: 0px !important;
       }
+      body > div.skiptranslate,
+      svg.VIpgJd-ZVi9od-aZ2wEe,
+      div.VIpgJd-ZVi9od-aZ2wEe-OiiCO,
+      div.VIpgJd-ZVi9od-aZ2wEe-OiiCO-ti6hGc,
       #goog-gt-tt {
         display: none !important;
       }

--- a/src/components/Home/LanguageBottomSheet.tsx
+++ b/src/components/Home/LanguageBottomSheet.tsx
@@ -162,7 +162,7 @@ const LanguageBottomSheet = ({
               <button
                 className="w-full text-left py-3 rounded-lg"
                 onClick={() => handleLanguageClick(lang.code)}
-                aria-label={`${lang.name}로 언어 변경`}
+                aria-label={`${lang.name}(으)로 언어 변경`}
                 aria-pressed={lang.code === currentLanguage}
                 disabled={isChanging || !isInitialized}
               >

--- a/src/components/ManageResume/InfoCard.tsx
+++ b/src/components/ManageResume/InfoCard.tsx
@@ -26,7 +26,7 @@ const InfoCard = <T,>({
       <InfoCardLayout icon={icon} title={title} rightTopElement={rightElement}>
         <button
           onClick={onAddClick}
-          className="w-full py-4 text-center border border-dashed border-blue-300 bg-blue-300/10 rounded-lg text-text-success flex items-center justify-center"
+          className="w-full py-4 text-center border border-dashed border-status-blue-300 bg-status-blue-50 rounded-lg text-text-success flex items-center justify-center"
         >
           <span className="mr-1">+</span>
           {addButtonText || `Add ${title}`}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,6 +76,7 @@ export default {
             400: '#E33E4E',
           },
           blue: {
+            50: '#F1F7FF',
             100: '#E0EDFF',
             200: '#A6C9FF',
             300: '#0066FF',


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #407 

## Work Description ✏️

<div align="center">
<img width="317px" src="https://github.com/user-attachments/assets/8808336d-8821-48b8-8c03-34a9203c925c" />
<img width="320px" src="https://github.com/user-attachments/assets/ce2d5e87-0f10-48fa-90f2-3d6cfc7e46c1" /> </div>
<div align="center"><p>좌 - 기존, 우 - 신규</p></div>

Google Translate의 번역 기능 사용 시, 간헐적으로 발생하는 무한 로딩 현상과 불필요한 UI(좌상단 로딩 ui, 호버 툴팁 등) 노출 문제를 해결했습니다. 또한, 사용자가 직접 번역을 해제하고 원본 언어로 되돌릴 수 있는 기능을 추가했습니다.

- Google Translate UI 문제 해결: `LanguageBottomSheet` 컴포넌트가 마운트될 때 Google Translate의 기본 UI를 숨기는 스타일을 동적으로 주입하고, 언마운트 시 제거하도록 구현
- 번역 해제 기능 추가: 언어 선택 바텀시트에 '없음' 옵션을 추가하여, 사용자가 번역을 명시적으로 해제할 수 있도록 지원
- 원본 복원 로직 구현: '없음' 선택 시, `TranslateElement` 인스턴스의 `restore()` 메서드를 호출하고 googtrans 쿠키를 제거하여 번역 상태를 완전히 초기화
- 단위 테스트 추가: 새로 추가된 번역 해제 및 인스턴스 관리 로직에 대한 단위 테스트를 추가
- 컬러 시스템에 `status-blue-50` 추가 및 기존 컬러 시스템 누락 부분 수정

## Uncompleted Tasks 😅

N/A

## To Reviewers 📢
- 번역을 원본으로 되돌리는 핵심 로직은 `src/utils/translate.ts`의 `revertToOriginal` 함수에 구현되어 있습니다. Google Translate 위젯 인스턴스를 저장해두었다가 `restore()` 메서드를 호출하는 방식으로 동작합니다.
- 기존에 `index.html`에 있던 번역 UI 숨김 스타일을 `LanguageBottomSheet.tsx` 컴포넌트로 이전하여, 컴포넌트의 생명주기에 맞춰 스타일을 관리하도록 개선했습니다. 이로써 불필요한 전역 스타일 의존성을 제거했습니다.
- 리뷰 시, 번역 기능 플로우(다른 언어 선택 -> '없음' 선택)가 의도대로 동작하는지 확인해주시면 감사하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Google 번역 위젯의 기본 UI 요소(배너, 툴팁 등)를 숨겨 앱 UI를 깔끔하게 유지합니다.
  - 번역을 비활성화하고 원래 언어(한국어)로 되돌릴 수 있는 "없음" 언어 옵션이 추가되었습니다.

- **버그 수정**
  - 언어 변경 시 진행 중에는 중복 변경이 되지 않도록 상태 관리가 개선되었습니다.

- **접근성 및 UI 개선**
  - 언어 선택 버튼의 접근성 텍스트가 한국어 문법에 맞게 수정되었습니다.
  - "추가" 버튼의 색상 스타일이 변경되어 더 일관된 디자인을 제공합니다.

- **테스트**
  - 번역 위젯 인스턴스 관리 및 "없음" 선택 동작 등 새로운 기능에 대한 테스트가 추가 및 개선되었습니다.

- **스타일**
  - Tailwind CSS에 새로운 파란색 계열 색상(#F1F7FF)이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->