### PR TITLE
[Feat/411] Chip 공용 컴포넌트 구현

### DIFF
--- a/src/assets/icons/DisclosureIcon.svg
+++ b/src/assets/icons/DisclosureIcon.svg
@@ -2,7 +2,7 @@
 width="16"
 height="16"
 viewBox="0 0 16 16"
-fill="none"
+fill="currentColor"
 xmlns="http://www.w3.org/2000/svg"
 stroke="currentColor" 
 >

--- a/src/components/Common/Chip.test.tsx
+++ b/src/components/Common/Chip.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import Chip from './Chip';
+import { ChipState } from '@/types/common/chip';
+
+// 아이콘 컴포넌트 Mocking
+vi.mock('@/assets/icons/DisclosureIcon.svg?react', () => ({
+  default: () => <div data-testid="disclosure-icon" />,
+}));
+
+describe('Chip', () => {
+  const defaultText = 'Chip 내용';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('렌더링', () => {
+    it('기본 텍스트를 올바르게 렌더링해야 한다', () => {
+      render(<Chip text={defaultText} />);
+      expect(screen.getByText(defaultText)).toBeInTheDocument();
+    });
+
+    it('props가 전달되지 않았을 때 기본값으로 렌더링되어야 한다', () => {
+      render(<Chip />);
+      const button = screen.getByRole('button');
+
+      expect(button).toHaveClass(
+        'border',
+        'border-border-disabled',
+        'text-text-strong',
+        'bg-surface-base',
+      );
+      expect(screen.queryByTestId('disclosure-icon')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('상호작용', () => {
+    it('버튼 클릭 시 onClick 핸들러가 호출되어야 한다', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+
+      render(<Chip text={defaultText} onClick={onClick} />);
+      const button = screen.getByRole('button');
+      await user.click(button);
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('조건부 렌더링', () => {
+    describe.each([
+      {
+        state: ChipState.DEFAULT,
+        expectedClasses: [
+          'border',
+          'border-border-disabled',
+          'text-text-strong',
+          'bg-surface-base',
+        ],
+      },
+      {
+        state: ChipState.PRESSED,
+        expectedClasses: ['text-text-strong', 'bg-surface-tertiary'],
+      },
+      {
+        state: ChipState.ACTIVE,
+        expectedClasses: ['text-text-invert', 'bg-surface-invert'],
+      },
+    ])(
+      'state=$state 상태에 맞는 스타일 적용 검사',
+      ({ state, expectedClasses }) => {
+        it(`${state} 상태에 맞는 스타일을 렌더링해야 한다`, () => {
+          render(<Chip state={state} text={defaultText} />);
+          const button = screen.getByRole('button');
+
+          expectedClasses.forEach((className) => {
+            expect(button).toHaveClass(className);
+          });
+        });
+      },
+    );
+
+    it('isDropdown이 true일 경우 드롭다운 아이콘을 렌더링해야 한다', () => {
+      render(<Chip text={defaultText} isDropdown />);
+      expect(screen.getByTestId('disclosure-icon')).toBeInTheDocument();
+    });
+
+    it('isDropdown이 false일 경우 드롭다운 아이콘을 렌더링하지 않아야 한다', () => {
+      render(<Chip text={defaultText} isDropdown={false} />);
+      expect(screen.queryByTestId('disclosure-icon')).not.toBeInTheDocument();
+    });
+
+    describe.each([
+      {
+        state: ChipState.DEFAULT,
+        expectedClass: 'text-text-alternative',
+      },
+      {
+        state: ChipState.PRESSED,
+        expectedClass: 'text-text-alternative',
+      },
+      {
+        state: ChipState.ACTIVE,
+        expectedClass: 'text-text-invert',
+      },
+    ])(
+      'state=$state 상태에 맞는 dropdownStyle 적용 검사',
+      ({ state, expectedClass }) => {
+        it(`${state} 상태일 때 dropdownStyle로 ${expectedClass}가 적용되어야 한다`, () => {
+          render(<Chip text="드롭다운" state={state} isDropdown={true} />);
+
+          // 텍스트(p 태그)에 클래스가 잘 적용됐는지 확인
+          const textElement = screen.getByText('드롭다운');
+          expect(textElement).toHaveClass(expectedClass);
+
+          // Dropdown 아이콘이 잘 적용됐는지 확인
+          expect(screen.getByTestId('disclosure-icon')).toBeInTheDocument();
+        });
+      },
+    );
+  });
+});

--- a/src/components/Common/Chip.tsx
+++ b/src/components/Common/Chip.tsx
@@ -1,0 +1,45 @@
+import { ChipState } from '@/types/common/chip';
+import Icon from '@/components/Common/Icon';
+import DisclosureIcon from '@/assets/icons/DisclosureIcon.svg?react';
+
+const STATE_STYLES: Record<ChipState, string> = {
+  [ChipState.DEFAULT]:
+    'border border-border-disabled text-text-strong bg-surface-base',
+  [ChipState.PRESSED]: 'text-text-strong bg-surface-tertiary',
+  [ChipState.ACTIVE]: 'text-text-invert bg-surface-invert',
+};
+
+const DROPDOWN_STYLES: Record<ChipState, string> = {
+  [ChipState.DEFAULT]: 'text-text-alternative',
+  [ChipState.PRESSED]: 'text-text-alternative',
+  [ChipState.ACTIVE]: 'text-text-invert',
+};
+
+type ChipType = {
+  state?: ChipState;
+  text?: string;
+  isDropdown?: boolean;
+  onClick?: () => void;
+};
+
+const Chip = ({
+  state = ChipState.DEFAULT,
+  text = '',
+  isDropdown = false,
+  onClick,
+}: ChipType) => {
+  const stateStyle = STATE_STYLES[state];
+  const dropdownStyle = DROPDOWN_STYLES[state];
+
+  return (
+    <button
+      className={`flex justify-center items-center py-2 px-[0.875rem] rounded-[3.125rem] body-14-regular ${stateStyle} ${isDropdown && 'pr-[0.625rem]'}`}
+      onClick={onClick}
+    >
+      <p className={`${isDropdown && dropdownStyle}`}>{text}</p>
+      {isDropdown && <Icon icon={DisclosureIcon} fillColor={dropdownStyle} />}
+    </button>
+  );
+};
+
+export default Chip;

--- a/src/components/PostSearch/CareerCardList.tsx
+++ b/src/components/PostSearch/CareerCardList.tsx
@@ -44,7 +44,7 @@ const CareerCard = ({ careerData }: { careerData: CareerListItemType }) => {
 
   return (
     <article
-      className="w-full p-4 border-t border-border-disabled bg-surface-base"
+      className="w-full p-4 bg-surface-base"
       onClick={() => goToCareerDetailPage(careerData)}
     >
       <Tag
@@ -142,7 +142,7 @@ const CareerCardList = ({
 
   return (
     <div className="flex flex-col flex-1 gap-4">
-      <div className="flex flex-row flex-wrap gap-4">
+      <div className="flex flex-wrap divide-y divide-border-disabled">
         {careerData.map((value: CareerListItemType) => (
           <CareerCard careerData={value} key={value.id} />
         ))}

--- a/src/components/PostSearch/CareerSearchSection.tsx
+++ b/src/components/PostSearch/CareerSearchSection.tsx
@@ -112,7 +112,7 @@ const CareerSearchSection = ({
         })}
       </nav>
       <section className="flex-1 flex flex-col items-center w-full pb-24">
-        <div className="w-full py-2 px-4 flex justify-between items-center">
+        <div className="w-full py-2 px-4 flex justify-between items-center border-b border-border-disabled">
           <h3 className="caption-12-regular text-text-normal">
             {careerData.length}{' '}
             {

--- a/src/components/PostSearch/CareerSearchSection.tsx
+++ b/src/components/PostSearch/CareerSearchSection.tsx
@@ -18,6 +18,8 @@ import {
   useInfiniteGetCareerGuestList,
   useInfiniteGetCareerList,
 } from '@/hooks/api/useCareer';
+import Chip from '@/components/Common/Chip';
+import { ChipState } from '@/types/common/chip';
 
 type CareerCategoryKey = keyof typeof CAREER_CATEGORY;
 
@@ -98,15 +100,14 @@ const CareerSearchSection = ({
           const isSelected = searchOption.careerCategory.includes(key);
 
           return (
-            <button
+            <Chip
               key={key}
-              className={`py-2 px-[0.875rem] rounded-[3.125rem] caption-12-regular ${isSelected ? 'text-text-invert bg-surface-invert' : 'text-text-strong bg-surface-secondary'}`}
+              state={isSelected ? ChipState.ACTIVE : ChipState.PRESSED}
+              text={label}
               onClick={() =>
                 handleUpdateCareerCategory(key as CareerCategoryKey)
               }
-            >
-              {label}
-            </button>
+            />
           );
         })}
       </nav>

--- a/src/pages/Employer/EmployeeSearch/EmployerEmployeeSearchPage.tsx
+++ b/src/pages/Employer/EmployeeSearch/EmployerEmployeeSearchPage.tsx
@@ -16,7 +16,6 @@ import { PostSortingType } from '@/types/PostSearchFilter/PostSearchFilterItem';
 import EmployerEmployeeSearchSortBottomSheet from '@/components/Employer/EmployeeSearch/EmployerEmployeeSearchSortBottomSheet';
 import DownArrowIcon from '@/assets/icons/PostSearch/DownArrowIconSm.svg?react';
 import EmployerEmployeeSearchFilterBottomSheet from '@/components/Employer/EmployeeSearch/EmployerEmployeeSearchFilterBottomSheet';
-import DisclosureIcon from '@/assets/icons/DisclosureIcon.svg?react';
 import { useInfiniteGetEmployeeResumeList } from '@/hooks/api/useResume';
 import { useUserStore } from '@/store/user';
 import { UserType } from '@/constants/user';
@@ -25,6 +24,8 @@ import { formatResumeSearchFilter } from '@/utils/formatSearchFilter';
 import EmployerEmployeeCardList from '@/components/Employer/EmployeeSearch/EmployerEmployeeCardList';
 import useNavigateBack from '@/hooks/useNavigateBack';
 import Icon from '@/components/Common/Icon';
+import Chip from '@/components/Common/Chip';
+import { ChipState } from '@/types/common/chip';
 
 export type EmployeeSearchOptionType = {
   filterList: EmployeeSearchFilterItemType;
@@ -101,29 +102,22 @@ const EmployerEmployeeSearchPage = () => {
               searchOption.filterList[category as EmployeeSearchCategoryEnType]
                 .length > 0;
             return (
-              <button
+              <Chip
                 key={category}
-                className={`flex items-center py-2 pl-[0.875rem] pr-[0.625rem] border border-border-disabled rounded-[3.125rem] body-14-regular ${isSelected ? 'bg-surface-invert text-text-invert' : 'text-text-alternative'}`}
+                state={isSelected ? ChipState.ACTIVE : ChipState.DEFAULT}
+                text={
+                  EMPLOYEE_SEARCH_CATEGORY_KO[
+                    category as EmployeeSearchCategoryEnType
+                  ] +
+                  (isSelected
+                    ? ` ${searchOption.filterList[category as EmployeeSearchCategoryEnType].length}`
+                    : '')
+                }
+                isDropdown={true}
                 onClick={() =>
                   handleOpenFilter(category as EmployeeSearchCategoryEnType)
                 }
-              >
-                <p>
-                  {
-                    EMPLOYEE_SEARCH_CATEGORY_KO[
-                      category as EmployeeSearchCategoryEnType
-                    ]
-                  }
-                  {isSelected &&
-                    `${' '}${searchOption.filterList[category as EmployeeSearchCategoryEnType].length}`}
-                </p>
-                <Icon
-                  icon={DisclosureIcon}
-                  fillColor={
-                    isSelected ? 'text-text-invert' : 'text-text-alternative'
-                  }
-                />
-              </button>
+              />
             );
           })}
         </div>

--- a/src/pages/Resume/ScrappedJobPostsPage.tsx
+++ b/src/pages/Resume/ScrappedJobPostsPage.tsx
@@ -14,6 +14,8 @@ import { JobPostingCard } from '@/components/Common/JobPostingCard';
 import CareerCardList from '@/components/PostSearch/CareerCardList';
 import { useCurrentPostIdStore } from '@/store/url';
 import { useNavigate } from 'react-router-dom';
+import Chip from '@/components/Common/Chip';
+import { ChipState } from '@/types/common/chip';
 
 const FILTERS = ['Job Posting', 'Career'] as const;
 type FilterType = (typeof FILTERS)[number];
@@ -47,7 +49,7 @@ const ScrappedJobPostList = ({
   }
 
   return (
-    <div className="w-full">
+    <div className="w-full divide-y divide-border-disabled">
       {jobPostingData.map((post) => (
         <article
           className="w-full"
@@ -147,25 +149,19 @@ const ScrappedJobPostsPage = () => {
       />
 
       {/* 필터 버튼 */}
-      <div className="flex gap-2 px-4 pb-2">
+      <div className="flex gap-2 px-4 pt-4">
         {FILTERS.map((filter) => {
           const isSelected = filter === selectedFilter;
           const count =
             filter === 'Job Posting' ? postList.length : careerList.length;
 
           return (
-            <button
+            <Chip
               key={filter}
-              className={`flex items-center gap-1 py-2 pl-[0.875rem] pr-[0.875rem] border border-border-disabled rounded-[3.125rem] body-14-regular ${
-                isSelected
-                  ? 'bg-surface-invert text-text-invert'
-                  : 'text-text-alternative'
-              }`}
+              state={isSelected ? ChipState.ACTIVE : ChipState.PRESSED}
+              text={`${filter} ${count}`}
               onClick={() => setSelectedFilter(filter)}
-            >
-              <p>{filter}</p>
-              <span>{count}</span>
-            </button>
+            />
           );
         })}
       </div>

--- a/src/types/common/chip.ts
+++ b/src/types/common/chip.ts
@@ -1,4 +1,4 @@
-export const enum ChipState {
+export enum ChipState {
   DEFAULT = 'default',
   PRESSED = 'pressed',
   ACTIVE = 'active',

--- a/src/types/common/chip.ts
+++ b/src/types/common/chip.ts
@@ -1,0 +1,5 @@
+export const enum ChipState {
+  DEFAULT = 'default',
+  PRESSED = 'pressed',
+  ACTIVE = 'active',
+}


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #411

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- Chip 공용 컴포넌트 구현

<img width="374" alt="스크린샷 2025-06-22 오전 11 54 15" src="https://github.com/user-attachments/assets/52acf420-a3fb-4b4d-9dcc-c4eb0db9d14a" />


- 인재 검색, 커리어 검색 페이지에 적용

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"

추후에 사용될 곳이 늘어날 컴포넌트라서 구현했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 새로운 Chip 컴포넌트가 추가되어 카테고리 및 필터 선택 UI에 적용되었습니다.

- **Refactor**
  - 기존 버튼 UI를 Chip 컴포넌트로 교체하여 스타일과 상태 관리가 일관되게 개선되었습니다.
  - 경력 카드 리스트 및 스크랩된 채용 공고 리스트에 구분선이 추가되어 시각적 구분이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->