### PR TITLE
Feature/415 이력서 완성 조건 분기 처리 UI 추가

### DIFF
--- a/src/api/resumes.ts
+++ b/src/api/resumes.ts
@@ -223,3 +223,9 @@ export const putScrapResume = async (id: string) => {
   const response = await api.put(`/owners/resumes/${id}/book-mark-resumes`);
   return response.data;
 };
+
+// 15.2 (유학생) 이력서 진행률 조회하기 (임시)
+export const getResumeProgress = async () => {
+  const response = await api.get(`/users/resumes/progress/`);
+  return response.data;
+};

--- a/src/api/resumes.ts
+++ b/src/api/resumes.ts
@@ -7,6 +7,7 @@ import {
   UserResumeDetailResponse,
   WorkExperienctRequest,
   WorkExperienceResponse,
+  ResumeProgressResponse,
 } from '@/types/api/resumes';
 import { api, apiV2 } from '.';
 import { RESTYPE } from '@/types/api/common';
@@ -203,7 +204,9 @@ export const getResumeDetail = async (id: string) => {
 };
 
 // 7.26 (유학생) 이력서 완성도 조회하기
-export const getResumeProgress = async () => {
+export const getResumeProgress = async (): Promise<
+  RESTYPE<ResumeProgressResponse>
+> => {
   const response = await api.get(`/users/resumes/completion-rate`);
   return response.data;
 };

--- a/src/api/resumes.ts
+++ b/src/api/resumes.ts
@@ -202,6 +202,12 @@ export const getResumeDetail = async (id: string) => {
   return response.data;
 };
 
+// 7.26 (유학생) 이력서 완성도 조회하기
+export const getResumeProgress = async () => {
+  const response = await api.get(`/users/resumes/completion-rate`);
+  return response.data;
+};
+
 // 9.1 (유학생) 학교 검색하기
 export const getSearchSchools = async ({
   search,
@@ -221,11 +227,5 @@ export const getSearchSchools = async ({
 // 15.1 (고용주) 인재 스크랩 추가/삭제
 export const putScrapResume = async (id: string) => {
   const response = await api.put(`/owners/resumes/${id}/book-mark-resumes`);
-  return response.data;
-};
-
-// 15.2 (유학생) 이력서 진행률 조회하기 (임시)
-export const getResumeProgress = async () => {
-  const response = await api.get(`/users/resumes/progress/`);
   return response.data;
 };

--- a/src/components/Home/HomeBanner.tsx
+++ b/src/components/Home/HomeBanner.tsx
@@ -12,6 +12,7 @@ import { BannerListType } from '@/types/api/banner';
 import { isEmployerByAccountType } from '@/utils/signup';
 import { bannerTranslation } from '@/constants/translation';
 import { useNavigate } from 'react-router-dom';
+import ResumeHelperBanner from '../ManageResume/ResumeHelperBanner';
 
 const RenderBannerList = ({
   data,
@@ -117,7 +118,7 @@ const HomeBanner = () => {
 
   return (
     <div className="w-full px-4">
-      <div className="pt-8">
+      <div className="pt-6 pb-4">
         <p className="pb-1 body-14-regular text-[#9397A1]">
           {getGreetingMessage(account_type)}
         </p>
@@ -127,6 +128,7 @@ const HomeBanner = () => {
             : 'Find your perfect job'}
         </h2>
       </div>
+      <ResumeHelperBanner />
       <section className="w-full mt-4 overflow-hidden relative" ref={emblaRef}>
         <RenderBannerList
           data={bannerData?.data?.banner_list}

--- a/src/components/Home/HomeBanner.tsx
+++ b/src/components/Home/HomeBanner.tsx
@@ -12,7 +12,7 @@ import { BannerListType } from '@/types/api/banner';
 import { isEmployerByAccountType } from '@/utils/signup';
 import { bannerTranslation } from '@/constants/translation';
 import { useNavigate } from 'react-router-dom';
-import ResumeHelperBanner from '../ManageResume/ResumeHelperBanner';
+import ResumeHelperBanner from '@/components/ManageResume/ResumeHelperBanner';
 
 const RenderBannerList = ({
   data,

--- a/src/components/ManageResume/ResumeHelperBanner.test.tsx
+++ b/src/components/ManageResume/ResumeHelperBanner.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@/__tests__/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useUserStore } from '@/store/user';
+import { useGetResumeProgress } from '@/hooks/api/useResume';
+import { UserType } from '@/constants/user';
+import ResumeHelperBanner from './ResumeHelperBanner';
+import { Mock } from 'vitest';
+
+// Mock dependencies
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: vi.fn(),
+    useNavigate: vi.fn(),
+  };
+});
+vi.mock('@/store/user');
+vi.mock('@/hooks/api/useResume');
+
+// Type casting mocks for intellisense
+const mockedUseLocation = useLocation as Mock;
+const mockedUseNavigate = useNavigate as Mock;
+const mockedUseUserStore = useUserStore as unknown as Mock;
+const mockedUseGetResumeProgress = useGetResumeProgress as Mock;
+
+describe('ResumeHelperBanner', () => {
+  const mockNavigate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+  });
+
+  describe('조건부 렌더링', () => {
+    it('유학생 유저가 아닐 경우 렌더링되지 않아야 한다', () => {
+      mockedUseUserStore.mockReturnValue({ account_type: UserType.OWNER });
+      mockedUseGetResumeProgress.mockReturnValue({ data: 50 });
+      mockedUseLocation.mockReturnValue({ pathname: '/' });
+
+      const { container } = render(<ResumeHelperBanner />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('이력서가 100% 완성된 경우 렌더링되지 않아야 한다', () => {
+      mockedUseUserStore.mockReturnValue({ account_type: UserType.USER });
+      mockedUseGetResumeProgress.mockReturnValue({ data: 100 });
+      mockedUseLocation.mockReturnValue({ pathname: '/' });
+
+      const { container } = render(<ResumeHelperBanner />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('유학생 유저이고 이력서가 미완성인 경우 렌더링되어야 한다', () => {
+      mockedUseUserStore.mockReturnValue({ account_type: UserType.USER });
+      mockedUseGetResumeProgress.mockReturnValue({ data: 80 });
+      mockedUseLocation.mockReturnValue({ pathname: '/' });
+
+      render(<ResumeHelperBanner />);
+
+      expect(screen.getByText("Let's finish your resume")).toBeInTheDocument();
+    });
+  });
+
+  describe('경로 기반 렌더링 및 상호작용', () => {
+    beforeEach(() => {
+      mockedUseUserStore.mockReturnValue({ account_type: UserType.USER });
+      mockedUseGetResumeProgress.mockReturnValue({ data: 60 });
+    });
+
+    describe("홈페이지('/')에 있을 때", () => {
+      beforeEach(() => {
+        mockedUseLocation.mockReturnValue({ pathname: '/' });
+      });
+
+      it('오른쪽 화살표 아이콘과 함께 렌더링되어야 한다', () => {
+        render(<ResumeHelperBanner />);
+        expect(
+          screen.getByLabelText('go to manage resume page'),
+        ).toBeInTheDocument();
+      });
+
+      it('배너를 클릭하면 이력서 관리 페이지(/profile/manage-resume)로 이동해야 한다', async () => {
+        const user = userEvent.setup();
+        render(<ResumeHelperBanner />);
+
+        await user.click(screen.getByText("Let's finish your resume"));
+
+        expect(mockNavigate).toHaveBeenCalledWith('/profile/manage-resume');
+      });
+    });
+
+    describe("프로필 페이지('/profile')에 있을 때", () => {
+      beforeEach(() => {
+        mockedUseLocation.mockReturnValue({ pathname: '/profile' });
+      });
+
+      it('"Manage your Resume" 버튼을 렌더링해야 하며, 배너 클릭 시에는 이동하지 않아야 한다', async () => {
+        const user = userEvent.setup();
+        const { container } = render(<ResumeHelperBanner />);
+
+        expect(
+          screen.getByRole('button', { name: 'Manage your Resume' }),
+        ).toBeInTheDocument();
+
+        await user.click(container.firstChild! as Element);
+        expect(mockNavigate).not.toHaveBeenCalled();
+      });
+
+      it('버튼을 클릭하면 이력서 관리 페이지(/profile/manage-resume)로 이동해야 한다', async () => {
+        const user = userEvent.setup();
+        render(<ResumeHelperBanner />);
+
+        const button = screen.getByRole('button', {
+          name: 'Manage your Resume',
+        });
+        await user.click(button);
+
+        expect(mockNavigate).toHaveBeenCalledWith('/profile/manage-resume');
+      });
+    });
+
+    describe("이력서 관리 페이지('/profile/manage-resume')에 있을 때", () => {
+      beforeEach(() => {
+        mockedUseLocation.mockReturnValue({
+          pathname: '/profile/manage-resume',
+        });
+      });
+
+      it('파란색 배경과 테두리 없이 렌더링되어야 한다', () => {
+        const { container } = render(<ResumeHelperBanner />);
+
+        const bannerElement = container.firstChild!;
+        expect(bannerElement).toHaveClass('bg-blue-50');
+        expect(bannerElement).not.toHaveClass('border rounded-xl');
+      });
+
+      it('우측 상단에 진행률 퍼센트를 표시해야 한다', () => {
+        mockedUseGetResumeProgress.mockReturnValue({ data: 60 });
+        render(<ResumeHelperBanner />);
+
+        const header = screen.getByText("Let's finish your resume")
+          .parentElement?.parentElement;
+        const percentageText = screen.getByText('60%');
+
+        expect(header).toContainElement(percentageText);
+      });
+    });
+  });
+});

--- a/src/components/ManageResume/ResumeHelperBanner.test.tsx
+++ b/src/components/ManageResume/ResumeHelperBanner.test.tsx
@@ -36,7 +36,12 @@ describe('ResumeHelperBanner', () => {
   describe('조건부 렌더링', () => {
     it('유학생 유저가 아닐 경우 렌더링되지 않아야 한다', () => {
       mockedUseUserStore.mockReturnValue({ account_type: UserType.OWNER });
-      mockedUseGetResumeProgress.mockReturnValue({ data: 50 });
+      mockedUseGetResumeProgress.mockReturnValue({
+        data: {
+          data: { completion_rate: 50, completion_text: 'test' },
+        },
+        isLoading: false,
+      });
       mockedUseLocation.mockReturnValue({ pathname: '/' });
 
       const { container } = render(<ResumeHelperBanner />);
@@ -46,7 +51,12 @@ describe('ResumeHelperBanner', () => {
 
     it('이력서가 100% 완성된 경우 렌더링되지 않아야 한다', () => {
       mockedUseUserStore.mockReturnValue({ account_type: UserType.USER });
-      mockedUseGetResumeProgress.mockReturnValue({ data: 100 });
+      mockedUseGetResumeProgress.mockReturnValue({
+        data: {
+          data: { completion_rate: 100, completion_text: 'test' },
+        },
+        isLoading: false,
+      });
       mockedUseLocation.mockReturnValue({ pathname: '/' });
 
       const { container } = render(<ResumeHelperBanner />);
@@ -56,7 +66,12 @@ describe('ResumeHelperBanner', () => {
 
     it('유학생 유저이고 이력서가 미완성인 경우 렌더링되어야 한다', () => {
       mockedUseUserStore.mockReturnValue({ account_type: UserType.USER });
-      mockedUseGetResumeProgress.mockReturnValue({ data: 80 });
+      mockedUseGetResumeProgress.mockReturnValue({
+        data: {
+          data: { completion_rate: 80, completion_text: 'test' },
+        },
+        isLoading: false,
+      });
       mockedUseLocation.mockReturnValue({ pathname: '/' });
 
       render(<ResumeHelperBanner />);
@@ -68,7 +83,12 @@ describe('ResumeHelperBanner', () => {
   describe('경로 기반 렌더링 및 상호작용', () => {
     beforeEach(() => {
       mockedUseUserStore.mockReturnValue({ account_type: UserType.USER });
-      mockedUseGetResumeProgress.mockReturnValue({ data: 60 });
+      mockedUseGetResumeProgress.mockReturnValue({
+        data: {
+          data: { completion_rate: 60, completion_text: 'test' },
+        },
+        isLoading: false,
+      });
     });
 
     describe("홈페이지('/')에 있을 때", () => {
@@ -139,7 +159,6 @@ describe('ResumeHelperBanner', () => {
       });
 
       it('우측 상단에 진행률 퍼센트를 표시해야 한다', () => {
-        mockedUseGetResumeProgress.mockReturnValue({ data: 60 });
         render(<ResumeHelperBanner />);
 
         const header = screen.getByText("Let's finish your resume")

--- a/src/components/ManageResume/ResumeHelperBanner.tsx
+++ b/src/components/ManageResume/ResumeHelperBanner.tsx
@@ -8,6 +8,18 @@ import Button from '@/components/Common/Button';
 import { buttonTypeKeys } from '@/constants/components';
 import { useGetResumeProgress } from '@/hooks/api/useResume';
 
+// 공통 텍스트 컴포넌트
+const BannerTextContent = () => (
+  <div className="flex flex-col items-start gap-0.5">
+    <h2 className="button-14-semibold text-text-strong">
+      Let's finish your resume
+    </h2>
+    <p className="caption-12-regular text-text-alternative">
+      Boost your chances of getting contacted by 90%!
+    </p>
+  </div>
+);
+
 // 이력서 진행률을 시각적으로 표시하는 프로그레스 바 컴포넌트
 const ProgressBar = ({
   resumeProgress,
@@ -37,6 +49,72 @@ const ProgressBar = ({
   );
 };
 
+// 홈 화면용 배너: 전체 클릭 가능, 클릭 시 /profile/manage-resume 페이지로 이동, 우측 상단 화살표 아이콘 표시
+const HomeResumeHelperBanner = ({
+  resumeProgress,
+  onClick,
+}: {
+  resumeProgress: number;
+  onClick: () => void;
+}) => (
+  <div
+    className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl"
+    onClick={onClick}
+  >
+    <section className="flex items-start justify-between">
+      <BannerTextContent />
+      <div
+        className="w-6 h-6 flex items-center justify-center"
+        aria-label="go to manage resume page"
+      >
+        <Icon name="arrow-right" icon={ChevronRightIcon} />
+      </div>
+    </section>
+    <ProgressBar resumeProgress={resumeProgress} />
+  </div>
+);
+
+// 프로필 페이지용 배너: '이력서 관리' 버튼을 통해서만 페이지 이동 가능
+const ProfileResumeHelperBanner = ({
+  resumeProgress,
+  onClick,
+}: {
+  resumeProgress: number;
+  onClick: () => void;
+}) => (
+  <div className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl">
+    <section className="flex items-start justify-between">
+      <BannerTextContent />
+    </section>
+    <ProgressBar resumeProgress={resumeProgress} />
+    <Button
+      type={buttonTypeKeys.LARGE}
+      isBorder={false}
+      onClick={onClick}
+      title="Manage your Resume"
+      bgColor="bg-surface-secondary"
+      fontColor="text-text-strong"
+    />
+  </div>
+);
+
+// 이력서 관리 페이지용 배너: 배경색, 레이아웃 변경 및 우측 상단에 진행률 텍스트 표시
+const ManageResumeHelperBanner = ({
+  resumeProgress,
+}: {
+  resumeProgress: number;
+}) => (
+  <div className="flex flex-col p-4 gap-3 bg-blue-50">
+    <section className="flex items-start justify-between">
+      <BannerTextContent />
+      <p className="button-14-semibold text-status-blue-300">
+        {resumeProgress}%
+      </p>
+    </section>
+    <ProgressBar resumeProgress={resumeProgress} showPercentage={false} />
+  </div>
+);
+
 // 이력서 완성을 독려하는 배너 컴포넌트
 const ResumeHelperBanner = () => {
   const { account_type } = useUserStore();
@@ -52,83 +130,29 @@ const ResumeHelperBanner = () => {
   // 일반 유저가 아니거나 이력서가 100% 완성된 경우에는 배너를 렌더링하지 않음
   if (!isUser || !isResumeIncomplete) return null;
 
+  const handleNavigate = () => navigate('/profile/manage-resume');
+
   // 현재 경로(pathname)에 따라 다른 버전의 배너를 렌더링
   switch (pathname) {
-    // 홈 화면: 전체 클릭 가능, 클릭 시 /profile/manage-resume 페이지로 이동, 우측 상단 화살표 아이콘 표시
+    // 홈 화면
     case '/':
       return (
-        <div
-          className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl"
-          onClick={() => {
-            navigate('/profile/manage-resume');
-          }}
-        >
-          <section className="flex items-start justify-between">
-            <div className="flex flex-col items-start gap-0.5">
-              <h2 className="button-14-semibold text-text-strong">
-                Let's finish your resume
-              </h2>
-              <p className="caption-12-regular text-text-alternative">
-                Boost your chances of getting contacted by 90%!
-              </p>
-            </div>
-            <div
-              className="w-6 h-6 flex items-center justify-center"
-              aria-label="go to manage resume page"
-            >
-              <Icon name="arrow-right" icon={ChevronRightIcon} />
-            </div>
-          </section>
-          <ProgressBar resumeProgress={resumeProgress} />
-        </div>
+        <HomeResumeHelperBanner
+          resumeProgress={resumeProgress}
+          onClick={handleNavigate}
+        />
       );
-    // 프로필 페이지: '이력서 관리' 버튼을 통해서만 페이지 이동 가능
+    // 프로필 페이지
     case '/profile':
       return (
-        <div className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl">
-          <section className="flex items-start justify-between">
-            <div className="flex flex-col items-start gap-0.5">
-              <h2 className="button-14-semibold text-text-strong">
-                Let's finish your resume
-              </h2>
-              <p className="caption-12-regular text-text-alternative">
-                Boost your chances of getting contacted by 90%!
-              </p>
-            </div>
-          </section>
-          <ProgressBar resumeProgress={resumeProgress} />
-          <Button
-            type={buttonTypeKeys.LARGE}
-            isBorder={false}
-            onClick={() => {
-              navigate('/profile/manage-resume');
-            }}
-            title="Manage your Resume"
-            bgColor="bg-surface-secondary"
-            fontColor="text-text-strong"
-          />
-        </div>
+        <ProfileResumeHelperBanner
+          resumeProgress={resumeProgress}
+          onClick={handleNavigate}
+        />
       );
-    // 이력서 관리 페이지: 배경색, 레이아웃 변경 및 우측 상단에 진행률 텍스트 표시
+    // 이력서 관리 페이지
     case '/profile/manage-resume':
-      return (
-        <div className="flex flex-col p-4 gap-3 bg-blue-50">
-          <section className="flex items-start justify-between">
-            <div className="flex flex-col items-start gap-0.5">
-              <h2 className="button-14-semibold text-text-strong">
-                Let's finish your resume
-              </h2>
-              <p className="caption-12-regular text-text-alternative">
-                Boost your chances of getting contacted by 90%!
-              </p>
-            </div>
-            <p className="button-14-semibold text-status-blue-300">
-              {resumeProgress}%
-            </p>
-          </section>
-          <ProgressBar resumeProgress={resumeProgress} showPercentage={false} />
-        </div>
-      );
+      return <ManageResumeHelperBanner resumeProgress={resumeProgress} />;
     default:
       return null;
   }

--- a/src/components/ManageResume/ResumeHelperBanner.tsx
+++ b/src/components/ManageResume/ResumeHelperBanner.tsx
@@ -58,23 +58,25 @@ const HomeResumeHelperBanner = ({
   resumeProgress,
   onClick,
   text,
-}: BannerProps) => (
-  <div
-    className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl"
-    onClick={onClick}
-  >
-    <section className="flex items-start justify-between">
-      <BannerTextContent text={text || ''} />
-      <div
-        className="w-6 h-6 flex items-center justify-center"
-        aria-label="go to manage resume page"
-      >
-        <Icon name="arrow-right" icon={ChevronRightIcon} />
-      </div>
-    </section>
-    <ProgressBar resumeProgress={resumeProgress} />
-  </div>
-);
+}: BannerProps) => {
+  return (
+    <div
+      className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl"
+      onClick={onClick}
+    >
+      <section className="flex items-start justify-between">
+        <BannerTextContent text={text || ''} />
+        <div
+          className="w-6 h-6 flex items-center justify-center"
+          aria-label="go to manage resume page"
+        >
+          <Icon name="arrow-right" icon={ChevronRightIcon} />
+        </div>
+      </section>
+      <ProgressBar resumeProgress={resumeProgress} />
+    </div>
+  );
+};
 
 // 프로필 페이지용 배너: '이력서 관리' 버튼을 통해서만 페이지 이동 가능
 const ProfileResumeHelperBanner = ({
@@ -121,8 +123,7 @@ const ResumeHelperBanner = () => {
   const { data: resumeProgress } = useGetResumeProgress();
 
   const isUser = account_type === UserType.USER;
-  const isResumeIncomplete = resumeProgress < 100;
-
+  const isResumeIncomplete = Number(resumeProgress?.data.completion_rate) < 100;
   // 일반 유저가 아니거나 이력서가 100% 완성된 경우에는 배너를 렌더링하지 않음
   if (!isUser || !isResumeIncomplete) return null;
 
@@ -134,7 +135,7 @@ const ResumeHelperBanner = () => {
     case '/':
       return (
         <HomeResumeHelperBanner
-          resumeProgress={resumeProgress}
+          resumeProgress={resumeProgress?.data.completion_rate || 0}
           text={resumeProgress?.data.completion_text}
           onClick={handleNavigate}
         />
@@ -143,7 +144,7 @@ const ResumeHelperBanner = () => {
     case '/profile':
       return (
         <ProfileResumeHelperBanner
-          resumeProgress={resumeProgress}
+          resumeProgress={resumeProgress?.data.completion_rate || 0}
           text={resumeProgress?.data.completion_text}
           onClick={handleNavigate}
         />
@@ -152,7 +153,7 @@ const ResumeHelperBanner = () => {
     case '/profile/manage-resume':
       return (
         <ManageResumeHelperBanner
-          resumeProgress={resumeProgress?.data.completion_rate}
+          resumeProgress={resumeProgress?.data.completion_rate || 0}
           text={resumeProgress?.data.completion_text}
         />
       );

--- a/src/components/ManageResume/ResumeHelperBanner.tsx
+++ b/src/components/ManageResume/ResumeHelperBanner.tsx
@@ -9,14 +9,12 @@ import { buttonTypeKeys } from '@/constants/components';
 import { useGetResumeProgress } from '@/hooks/api/useResume';
 
 // 공통 텍스트 컴포넌트
-const BannerTextContent = () => (
+const BannerTextContent = ({ text }: { text: string }) => (
   <div className="flex flex-col items-start gap-0.5">
     <h2 className="button-14-semibold text-text-strong">
       Let's finish your resume
     </h2>
-    <p className="caption-12-regular text-text-alternative">
-      Boost your chances of getting contacted by 90%!
-    </p>
+    <p className="caption-12-regular text-text-alternative">{text}</p>
   </div>
 );
 
@@ -49,20 +47,24 @@ const ProgressBar = ({
   );
 };
 
+type BannerProps = {
+  resumeProgress: number;
+  onClick?: () => void;
+  text?: string;
+};
+
 // 홈 화면용 배너: 전체 클릭 가능, 클릭 시 /profile/manage-resume 페이지로 이동, 우측 상단 화살표 아이콘 표시
 const HomeResumeHelperBanner = ({
   resumeProgress,
   onClick,
-}: {
-  resumeProgress: number;
-  onClick: () => void;
-}) => (
+  text,
+}: BannerProps) => (
   <div
     className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl"
     onClick={onClick}
   >
     <section className="flex items-start justify-between">
-      <BannerTextContent />
+      <BannerTextContent text={text || ''} />
       <div
         className="w-6 h-6 flex items-center justify-center"
         aria-label="go to manage resume page"
@@ -78,13 +80,11 @@ const HomeResumeHelperBanner = ({
 const ProfileResumeHelperBanner = ({
   resumeProgress,
   onClick,
-}: {
-  resumeProgress: number;
-  onClick: () => void;
-}) => (
+  text,
+}: BannerProps) => (
   <div className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl">
     <section className="flex items-start justify-between">
-      <BannerTextContent />
+      <BannerTextContent text={text || ''} />
     </section>
     <ProgressBar resumeProgress={resumeProgress} />
     <Button
@@ -99,14 +99,10 @@ const ProfileResumeHelperBanner = ({
 );
 
 // 이력서 관리 페이지용 배너: 배경색, 레이아웃 변경 및 우측 상단에 진행률 텍스트 표시
-const ManageResumeHelperBanner = ({
-  resumeProgress,
-}: {
-  resumeProgress: number;
-}) => (
+const ManageResumeHelperBanner = ({ resumeProgress, text }: BannerProps) => (
   <div className="flex flex-col p-4 gap-3 bg-blue-50">
     <section className="flex items-start justify-between">
-      <BannerTextContent />
+      <BannerTextContent text={text || ''} />
       <p className="button-14-semibold text-status-blue-300">
         {resumeProgress}%
       </p>
@@ -139,6 +135,7 @@ const ResumeHelperBanner = () => {
       return (
         <HomeResumeHelperBanner
           resumeProgress={resumeProgress}
+          text={resumeProgress?.data.completion_text}
           onClick={handleNavigate}
         />
       );
@@ -147,12 +144,18 @@ const ResumeHelperBanner = () => {
       return (
         <ProfileResumeHelperBanner
           resumeProgress={resumeProgress}
+          text={resumeProgress?.data.completion_text}
           onClick={handleNavigate}
         />
       );
     // 이력서 관리 페이지
     case '/profile/manage-resume':
-      return <ManageResumeHelperBanner resumeProgress={resumeProgress} />;
+      return (
+        <ManageResumeHelperBanner
+          resumeProgress={resumeProgress?.data.completion_rate}
+          text={resumeProgress?.data.completion_text}
+        />
+      );
     default:
       return null;
   }

--- a/src/components/ManageResume/ResumeHelperBanner.tsx
+++ b/src/components/ManageResume/ResumeHelperBanner.tsx
@@ -6,6 +6,7 @@ import ChevronRightIcon from '@/assets/icons/Chevron.svg?react';
 import { motion } from 'framer-motion';
 import Button from '@/components/Common/Button';
 import { buttonTypeKeys } from '@/constants/components';
+import { useGetResumeProgress } from '@/hooks/api/useResume';
 
 // 이력서 진행률을 시각적으로 표시하는 프로그레스 바 컴포넌트
 const ProgressBar = ({
@@ -43,7 +44,7 @@ const ResumeHelperBanner = () => {
   const navigate = useNavigate();
 
   // TODO: API 연동 시 실제 이력서 진행도를 받아와야 함
-  const resumeProgress = 60;
+  const { data: resumeProgress } = useGetResumeProgress();
 
   const isUser = account_type === UserType.USER;
   const isResumeIncomplete = resumeProgress < 100;
@@ -71,7 +72,10 @@ const ResumeHelperBanner = () => {
                 Boost your chances of getting contacted by 90%!
               </p>
             </div>
-            <div className="w-6 h-6 flex items-center justify-center">
+            <div
+              className="w-6 h-6 flex items-center justify-center"
+              aria-label="go to manage resume page"
+            >
               <Icon name="arrow-right" icon={ChevronRightIcon} />
             </div>
           </section>

--- a/src/components/ManageResume/ResumeHelperBanner.tsx
+++ b/src/components/ManageResume/ResumeHelperBanner.tsx
@@ -1,0 +1,133 @@
+import { UserType } from '@/constants/user';
+import { useUserStore } from '@/store/user';
+import { useLocation, useNavigate } from 'react-router-dom';
+import Icon from '@/components/Common/Icon';
+import ChevronRightIcon from '@/assets/icons/Chevron.svg?react';
+import { motion } from 'framer-motion';
+import Button from '@/components/Common/Button';
+import { buttonTypeKeys } from '@/constants/components';
+
+// 이력서 진행률을 시각적으로 표시하는 프로그레스 바 컴포넌트
+const ProgressBar = ({
+  resumeProgress,
+  showPercentage = true,
+}: {
+  resumeProgress: number;
+  showPercentage?: boolean;
+}) => {
+  return (
+    <section>
+      <div className="flex items-center">
+        <div className="w-full h-2 rounded-full bg-surface-tertiary">
+          <motion.div
+            className="h-2 rounded-full bg-status-blue-300"
+            initial={{ width: 0 }}
+            animate={{ width: `${resumeProgress}%` }}
+            transition={{ duration: 1, ease: 'easeInOut' }}
+          />
+        </div>
+        {showPercentage && (
+          <p className="pl-[0.675rem] button-14-semibold text-status-blue-300">
+            {resumeProgress}%
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+// 이력서 완성을 독려하는 배너 컴포넌트
+const ResumeHelperBanner = () => {
+  const { account_type } = useUserStore();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  // TODO: API 연동 시 실제 이력서 진행도를 받아와야 함
+  const resumeProgress = 60;
+
+  const isUser = account_type === UserType.USER;
+  const isResumeIncomplete = resumeProgress < 100;
+
+  // 일반 유저가 아니거나 이력서가 100% 완성된 경우에는 배너를 렌더링하지 않음
+  if (!isUser || !isResumeIncomplete) return null;
+
+  // 현재 경로(pathname)에 따라 다른 버전의 배너를 렌더링
+  switch (pathname) {
+    // 홈 화면: 전체 클릭 가능, 클릭 시 /profile/manage-resume 페이지로 이동, 우측 상단 화살표 아이콘 표시
+    case '/':
+      return (
+        <div
+          className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl"
+          onClick={() => {
+            navigate('/profile/manage-resume');
+          }}
+        >
+          <section className="flex items-start justify-between">
+            <div className="flex flex-col items-start gap-0.5">
+              <h2 className="button-14-semibold text-text-strong">
+                Let's finish your resume
+              </h2>
+              <p className="caption-12-regular text-text-alternative">
+                Boost your chances of getting contacted by 90%!
+              </p>
+            </div>
+            <div className="w-6 h-6 flex items-center justify-center">
+              <Icon name="arrow-right" icon={ChevronRightIcon} />
+            </div>
+          </section>
+          <ProgressBar resumeProgress={resumeProgress} />
+        </div>
+      );
+    // 프로필 페이지: '이력서 관리' 버튼을 통해서만 페이지 이동 가능
+    case '/profile':
+      return (
+        <div className="flex flex-col p-4 gap-3 border border-border-disabled rounded-xl">
+          <section className="flex items-start justify-between">
+            <div className="flex flex-col items-start gap-0.5">
+              <h2 className="button-14-semibold text-text-strong">
+                Let's finish your resume
+              </h2>
+              <p className="caption-12-regular text-text-alternative">
+                Boost your chances of getting contacted by 90%!
+              </p>
+            </div>
+          </section>
+          <ProgressBar resumeProgress={resumeProgress} />
+          <Button
+            type={buttonTypeKeys.LARGE}
+            isBorder={false}
+            onClick={() => {
+              navigate('/profile/manage-resume');
+            }}
+            title="Manage your Resume"
+            bgColor="bg-surface-secondary"
+            fontColor="text-text-strong"
+          />
+        </div>
+      );
+    // 이력서 관리 페이지: 배경색, 레이아웃 변경 및 우측 상단에 진행률 텍스트 표시
+    case '/profile/manage-resume':
+      return (
+        <div className="flex flex-col p-4 gap-3 bg-blue-50">
+          <section className="flex items-start justify-between">
+            <div className="flex flex-col items-start gap-0.5">
+              <h2 className="button-14-semibold text-text-strong">
+                Let's finish your resume
+              </h2>
+              <p className="caption-12-regular text-text-alternative">
+                Boost your chances of getting contacted by 90%!
+              </p>
+            </div>
+            <p className="button-14-semibold text-status-blue-300">
+              {resumeProgress}%
+            </p>
+          </section>
+          <ProgressBar resumeProgress={resumeProgress} showPercentage={false} />
+        </div>
+      );
+    default:
+      return null;
+  }
+};
+
+export default ResumeHelperBanner;

--- a/src/components/Profile/ApplicationStatus.tsx
+++ b/src/components/Profile/ApplicationStatus.tsx
@@ -4,12 +4,11 @@ import {
 } from '@/hooks/api/useProfile';
 import { ApplicationCountType, BookmarkCountType } from '@/types/api/profile';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import ResumeHelperBanner from '../ManageResume/ResumeHelperBanner';
 
 const ApplicationStatus = () => {
   const { data: applicationData } = useGetApplicationCounts();
   const { data: bookmarkData } = userGetBookmarksCounts();
-  const navigate = useNavigate();
 
   const [applicationCounts, setApplicationCounts] =
     useState<ApplicationCountType>({
@@ -58,12 +57,7 @@ const ApplicationStatus = () => {
         ))}
       </div>
       <div className="px-4">
-        <button
-          className="grow w-full bg-[#FEF387] rounded-lg px-5 py-3 text-center button-14-semibold text-text-strong"
-          onClick={() => navigate('/profile/manage-resume')}
-        >
-          Manage your Resume
-        </button>
+        <ResumeHelperBanner />
       </div>
     </>
   );

--- a/src/hooks/api/useResume.ts
+++ b/src/hooks/api/useResume.ts
@@ -7,6 +7,7 @@ import {
   getEmployeeResumeList,
   getResume,
   getResumeDetail,
+  getResumeProgress,
   getSearchSchools,
   getWorkExperience,
   getWorkPreference,
@@ -439,5 +440,13 @@ export const usePutScrapResume = () => {
     meta: {
       skipGlobalLoading: true,
     },
+  });
+};
+
+// 15.2 (유학생) 이력서 진행률 조회하기 (임시)
+export const useGetResumeProgress = () => {
+  return useQuery({
+    queryKey: ['resume', 'progress'],
+    queryFn: () => getResumeProgress(),
   });
 };

--- a/src/hooks/api/useResume.ts
+++ b/src/hooks/api/useResume.ts
@@ -331,6 +331,14 @@ export const useGetResumeDetail = (id: string, isEnabled: boolean) => {
   });
 };
 
+// 7.26 (유학생) 이력서 완성도 조회하기
+export const useGetResumeProgress = () => {
+  return useQuery({
+    queryKey: ['resume', 'progress'],
+    queryFn: getResumeProgress,
+  });
+};
+
 // 9.1 (유학생) 학교 검색하기
 export const useGetSearchSchools = (
   search: string,
@@ -440,13 +448,5 @@ export const usePutScrapResume = () => {
     meta: {
       skipGlobalLoading: true,
     },
-  });
-};
-
-// 15.2 (유학생) 이력서 진행률 조회하기 (임시)
-export const useGetResumeProgress = () => {
-  return useQuery({
-    queryKey: ['resume', 'progress'],
-    queryFn: () => getResumeProgress(),
   });
 };

--- a/src/pages/Resume/ManageResumePage.tsx
+++ b/src/pages/Resume/ManageResumePage.tsx
@@ -1,4 +1,5 @@
 import BaseHeader from '@/components/Common/Header/BaseHeader';
+import ResumeHelperBanner from '@/components/ManageResume/ResumeHelperBanner';
 import PostApplyResume from '@/components/PostApply/PostApplyResume';
 import useNavigateBack from '@/hooks/useNavigateBack';
 
@@ -13,6 +14,7 @@ const ManageResumePage = () => {
         hasMenuButton={false}
         title="Manage Resume"
       />
+      <ResumeHelperBanner />
       <PostApplyResume />
     </>
   );

--- a/src/types/api/resumes.ts
+++ b/src/types/api/resumes.ts
@@ -113,6 +113,12 @@ export type GetEmployeeResumeListReq = {
   is_book_marked?: boolean;
 };
 
+// 7.26 (유학생) 이력서 완성도 조회하기
+export type ResumeProgressResponse = {
+  completion_rate: number;
+  completion_text: string;
+};
+
 // (고용주) 이력서 리스트 조회 검색 필터
 export type EmployeeSearchCategoryEnType =
   keyof typeof EMPLOYEE_SEARCH_CATEGORY; // 'VISA' | 'INDUSTRY' | ...


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #415 

## Work Description ✏️
<div align="center"><img width="320px" src="https://github.com/user-attachments/assets/d799cd2a-ccbb-4163-8334-b3a2d76054ac" /></div>

유학생 사용자의 이력서 작성을 유도하고, 완성률을 시각적으로 보여주는 `ResumeHelperBanner` 컴포넌트 추가
- 이력서 완성도 조회 로직 (임시) 추가(`getResumeProgress`, `useGetResumeProgress`)
- 페이지 경로(홈, 프로필, 이력서 관리)에 따른 ui 및 기능을 가진 컴포넌트 3가지 조건부 렌더링
- 홈, 프로필, 이력서 관리 페이지에 컴포넌트 적용
- 테스트 코드 작성

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

- [ ] 이력서 진행률 조회 api 백엔드 스펙 확정 시 수정 필요

## To Reviewers 📢
`ResumeHelperBanner` 는 렌더링 되는 페이지에 따라 UI와 클릭 시 동작이 다릅니다. 처음에는 `switch` 문으로 모든 로직을 처리했는데, 각 case를 별도의 컴포넌트로 분리하는 리팩토링을 진행했습니다. 이 구조에 대한 리뷰어분들의 의견 주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 다양한 페이지(홈, 프로필, 이력서 관리)에 이력서 완성도를 보여주는 배너가 추가되었습니다. 이 배너는 사용자의 이력서 진행 상황을 시각적으로 안내하고, 이력서 관리 페이지로 쉽게 이동할 수 있도록 도와줍니다.
    - 홈 배너에 이력서 도움 배너가 추가되어 사용자에게 맞춤형 이력서 진행 상황을 제공합니다.
    - 이력서 완성도 정보를 API를 통해 실시간으로 조회하는 기능이 도입되었습니다.

- **테스트**
    - 이력서 도움 배너 컴포넌트의 조건별 렌더링 및 페이지별 상호작용을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->