### PR TITLE
fix/425 공고 지원 버튼 width 누락 수정

### DIFF
--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -72,7 +72,7 @@ const Button = ({
       case buttonTypeKeys.SMALL:
         return 'w-[24vw] py-3 rounded-lg button-14-semibold';
       case buttonTypeKeys.APPLY:
-        return `py-4 rounded-xl bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
+        return `w-full py-4 rounded-xl bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
       case buttonTypeKeys.SMALLAPPLY: // 스크랩 버튼과 함께 쓰이는 Apply 버튼
         return `w-[71vw] py-4 rounded-lg bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
       case buttonTypeKeys.BACK: // CONTINUE 버튼과 같은 열에 사용


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #425 
<div align="center"><img width="320" alt="스크린샷 2025-06-26 오후 3 30 41" src="https://github.com/user-attachments/assets/822d1a2c-1d6c-4c5b-a063-2a6bcbda3154" />
<img width="320" alt="스크린샷 2025-06-26 오후 3 29 56" src="https://github.com/user-attachments/assets/751babb6-5c70-4fd3-ab05-5baa7be5fac7" /></div>

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- 공고 지원시 사용되는 버튼에 Button 컴포넌트 리팩토링 후 w-full이 누락되어있던 코드 수정

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

단순한 css 클래스 누락이라 리뷰 없이 merge하겠습니다.
