### PR TITLE
[Feat/435] Icon 컴포넌트 크기 및 패딩 variant 추가

### DIFF
--- a/src/components/Common/ButtonText.test.tsx
+++ b/src/components/Common/ButtonText.test.tsx
@@ -63,7 +63,9 @@ describe('ButtonText', () => {
       const contentContainer = screen.getByText('아이콘');
       const children = Array.from(contentContainer?.childNodes ?? []);
       const iconIndex = children.findIndex(
-        (node) => node.nodeName.toLowerCase() === 'svg',
+        (node) =>
+          node.nodeType === Node.ELEMENT_NODE &&
+          (node as HTMLElement).dataset.testid === 'svg-icon',
       );
       const textIndex = children.findIndex(
         (node) =>
@@ -85,7 +87,9 @@ describe('ButtonText', () => {
       const contentContainer = screen.getByText('아이콘');
       const children = Array.from(contentContainer?.childNodes ?? []);
       const iconIndex = children.findIndex(
-        (node) => node.nodeName.toLowerCase() === 'svg',
+        (node) =>
+          node.nodeType === Node.ELEMENT_NODE &&
+          (node as HTMLElement).dataset.testid === 'svg-icon',
       );
       const textIndex = children.findIndex(
         (node) =>

--- a/src/components/Common/Header/BaseHeader.tsx
+++ b/src/components/Common/Header/BaseHeader.tsx
@@ -1,5 +1,6 @@
 import BackButtonIcon from '@/assets/icons/BackButtonIcon.svg?react';
 import RowMenuIcon from '@/assets/icons/RowMenuIcon.svg?react';
+import Icon from '@/components/Common/Icon';
 
 type HeaderProps = {
   hasBackButton: boolean; // 뒤로 가기 버튼 여부
@@ -19,8 +20,8 @@ const BaseHeader = ({
   return (
     <section className="w-full h-[3.75rem] pl-[0.5rem] pr-[0.75rem] py-[0.75rem] flex justify-between items-center bg-white sticky top-0 z-40">
       {hasBackButton ? (
-        <button className="p-[0.5rem] border-white" onClick={onClickBackButton}>
-          <BackButtonIcon />
+        <button onClick={onClickBackButton}>
+          <Icon icon={BackButtonIcon} size={Icon.Size.MD} hasPadding={true} />
         </button>
       ) : (
         <div className="w-[2.5rem] h-[2.5rem]"></div>

--- a/src/components/Common/Icon.tsx
+++ b/src/components/Common/Icon.tsx
@@ -67,7 +67,10 @@ const Icon = ({
     .join(' ');
 
   return (
-    <div className={sizeStyle && hasPadding ? sizeStyle.padding : ''}>
+    <div
+      className={sizeStyle && hasPadding ? sizeStyle.padding : ''}
+      data-testid="svg-icon"
+    >
       <IconComponent className={combinedClassName} {...props} />
     </div>
   );

--- a/src/components/Common/Icon.tsx
+++ b/src/components/Common/Icon.tsx
@@ -1,18 +1,47 @@
 import React from 'react';
 
+enum IconSize {
+  XSM = 'xsm',
+  SM = 'sm',
+  MD = 'md',
+  LG = 'lg',
+}
+
+const SIZE_STYLES: Record<IconSize, { widthHeight: string; padding: string }> =
+  {
+    [IconSize.LG]: {
+      widthHeight: 'w-8 h-8',
+      padding: 'p-2',
+    },
+    [IconSize.MD]: {
+      widthHeight: 'w-6 h-6',
+      padding: 'p-[0.375rem]',
+    },
+    [IconSize.SM]: {
+      widthHeight: 'w-4 h-4',
+      padding: 'p-1',
+    },
+    [IconSize.XSM]: {
+      widthHeight: 'w-3 h-3',
+      padding: 'p-[0.188rem]',
+    },
+  };
+
 type IconProps = {
   /**
    * 이 컴포넌트는 SVGR을 사용하여 아이콘을 렌더링합니다.
    * SVGR은 SVG 파일을 React 컴포넌트로 변환하는 도구입니다.
    * 이 컴포넌트는 아이콘 컴포넌트를 렌더링할 때 필요한 모든 속성을 전달합니다.
    * 예를 들어, `width`, `height`, `className` 등의 속성을 전달할 수 있습니다.
+   *
+   * hasPadding을 사용하려면 size가 정의되어야 합니다.
    */
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   bgColor?: string;
   strokeColor?: string;
   fillColor?: string;
-  width?: string;
-  height?: string;
+  size?: IconSize;
+  hasPadding?: boolean; // 아이콘 버튼 사용 시에 padding 추가 (size props가 정의되어야 사용 가능)
 } & React.SVGProps<SVGSVGElement>;
 
 const Icon = ({
@@ -20,19 +49,30 @@ const Icon = ({
   bgColor,
   strokeColor,
   fillColor,
+  size,
+  hasPadding,
   className,
   ...props
 }: IconProps) => {
-  const combinedClassName = [className, bgColor, strokeColor, fillColor]
+  const sizeStyle = size ? SIZE_STYLES[size] : undefined;
+
+  const combinedClassName = [
+    className,
+    bgColor,
+    strokeColor,
+    fillColor,
+    sizeStyle?.widthHeight,
+  ]
     .filter(Boolean)
     .join(' ');
 
   return (
-    <IconComponent
-      className={combinedClassName}
-      {...props}
-    />
+    <div className={sizeStyle && hasPadding ? sizeStyle.padding : ''}>
+      <IconComponent className={combinedClassName} {...props} />
+    </div>
   );
 };
+
+Icon.Size = IconSize;
 
 export default Icon;


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #435

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- Icon 컴포넌트에서 크기와 패딩 variant를 추가했습니다
- 기존에 크기를 사용하지 않았던 경우와도 호환되도록 size props는 선택값입니다! 따라서 size props와 hasPadding이 true로 전달될 때만 각 size에 따른 padding도 추가가 가능합니다.
- 우선적으로 BaseHeader의 뒤로가기 버튼에만 적용해두었습니다.

<img width="338" alt="스크린샷 2025-06-28 오후 5 03 45" src="https://github.com/user-attachments/assets/ef5d3ad0-3317-481d-a72d-ae99899abd7f" />


## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 아이콘 컴포넌트에 네 가지 크기 옵션과 패딩 설정 기능이 추가되었습니다.

* **스타일**
  * 헤더의 뒤로가기 버튼 아이콘이 새로운 아이콘 컴포넌트를 사용하도록 변경되었으며, 버튼의 스타일이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->