### PR TITLE
Fix/457 구 버전 button 컴포넌트 레이아웃 깨짐 현상 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/giggle_logo.svg" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <!-- Google tag (gtag.js) -->
     <script

--- a/src/components/ApplicationDetail/ApplicationDetailStep1.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep1.tsx
@@ -1,13 +1,12 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 const ApplicationDetailStep1 = () => {
   return (
     <>
       <section className="w-full px-4 pb-[3.125rem]">
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={'bg-primary-neutral'}
-          fontColor="text-text-disabled"
+          type={Button.Type.NEUTRAL}
+          size={Button.Size.LG}
+          isFullWidth
           title="Waiting for employer approval"
         />
       </section>

--- a/src/components/ApplicationDetail/ApplicationDetailStep2.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep2.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 
 const ApplicationDetailStep2 = () => {
@@ -6,9 +5,9 @@ const ApplicationDetailStep2 = () => {
     <>
       <section className="w-full px-4 pb-[3.125rem]">
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={'bg-primary-neutral'}
-          fontColor="text-text-disabled"
+          type={Button.Type.NEUTRAL}
+          size={Button.Size.LG}
+          isFullWidth
           title="Check the application documents"
         />
       </section>

--- a/src/components/ApplicationDetail/ApplicationDetailStep3.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep3.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { useNavigate } from 'react-router-dom';
 
@@ -8,9 +7,9 @@ const ApplicationDetailStep3 = ({ applicant_id }: { applicant_id: number }) => {
   return (
     <section className="w-full px-4 pt-3 pb-[3.125rem]">
       <Button
-        type={buttonTypeKeys.APPLY}
-        bgColor={'bg-primary-normal'}
-        fontColor="text-surface-invert"
+        type={Button.Type.PRIMARY}
+        size={Button.Size.LG}
+        isFullWidth
         title="Check the application documents"
         onClick={() => navigate(`/application-documents/${applicant_id}`)}
       />

--- a/src/components/ApplicationDetail/ApplicationDetailStep4.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep4.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -10,16 +9,16 @@ const ApplicationDetailStep4 = () => {
     <>
       <section className="flex flex-col gap-2 w-full px-4 pt-3 pb-[3.125rem]">
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={'bg-primary-normal'}
-          fontColor="text-surface-invert"
+          type={Button.Type.PRIMARY}
+          size={Button.Size.LG}
+          isFullWidth
           title="Continue"
           onClick={() => navigate(`/application/${id}/school`)}
         />
         <Button
-          type={buttonTypeKeys.APPLY}
-          bgColor={'bg-primary-neutral'}
-          fontColor="text-surface-invert"
+          type={Button.Type.NEUTRAL}
+          size={Button.Size.LG}
+          isFullWidth
           title="Check the application documents"
           onClick={() =>
             navigate(`/application-documents/${id}`, {

--- a/src/components/ApplicationDetail/ApplicationDetailStep5.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep5.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useState } from 'react';
@@ -14,16 +13,16 @@ const ApplicationDetailStep5 = () => {
     <>
       <section className="flex flex-col gap-2 w-full px-4 pt-3 pb-[3.125rem]">
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={'bg-primary-normal'}
-          fontColor="text-surface-invert"
+          type={Button.Type.PRIMARY}
+          size={Button.Size.LG}
+          isFullWidth
           title="Apply through HiKorea"
           onClick={() => setIsShowBottomSheet(true)}
         />
         <Button
-          type={buttonTypeKeys.APPLY}
-          bgColor={'bg-primary-neutral'}
-          fontColor="text-surface-invert"
+          type={Button.Type.NEUTRAL}
+          size={Button.Size.LG}
+          isFullWidth
           title="Check the application documents"
           onClick={() =>
             navigate(`/application-documents/${id}`, {

--- a/src/components/ApplicationDetail/ApplicationDetailStep6.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep6.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -9,16 +8,16 @@ const ApplicationDetailStep6 = () => {
   return (
     <section className="flex flex-col gap-2 w-full px-4 pt-3 pb-[3.125rem]">
       <Button
-        type={buttonTypeKeys.LARGE}
-        bgColor={'bg-primary-normal'}
-        fontColor="text-surface-invert"
+        type={Button.Type.PRIMARY}
+        size={Button.Size.LG}
+        isFullWidth
         title="Register the results"
         onClick={() => navigate(`/application/result/${id}`)}
       />
       <Button
-        type={buttonTypeKeys.APPLY}
-        bgColor={'bg-primary-neutral'}
-        fontColor="text-surface-invert"
+        type={Button.Type.NEUTRAL}
+        size={Button.Size.LG}
+        isFullWidth
         title="Check the application documents"
         onClick={() =>
           navigate(`/application-documents/${id}`, {

--- a/src/components/ApplicationDetail/ApplicationDetailStep7.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStep7.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -9,9 +8,9 @@ const ApplicationDetailStep7 = () => {
   return (
     <section className="w-full px-4 pt-3 pb-[3.125rem]">
       <Button
-        type={buttonTypeKeys.APPLY}
-        bgColor={'bg-primary-normal'}
-        fontColor="text-surface-invert"
+        type={Button.Type.PRIMARY}
+        size={Button.Size.LG}
+        isFullWidth
         title="Check the application documents"
         onClick={() =>
           navigate(`/application-documents/${id}`, {

--- a/src/components/ApplicationDetail/ApplicationDetailStepEtc.tsx
+++ b/src/components/ApplicationDetail/ApplicationDetailStepEtc.tsx
@@ -1,7 +1,6 @@
 import { APPLICATION_STEP } from '@/constants/application';
 import { ApplicationStepType } from '@/types/application/applicationItem';
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 
 type ApplicationDetailStepEtcProps = {
   result: ApplicationStepType;
@@ -14,9 +13,9 @@ const ApplicationDetailStepEtc = ({
     <>
       <section className="w-full px-4 pb-[3.125rem]">
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={'bg-primary-neutral'}
-          fontColor="text-text-disabled"
+          type={Button.Type.NEUTRAL}
+          size={Button.Size.LG}
+          isFullWidth
           title={
             result === APPLICATION_STEP.PENDING
               ? "I'm on standby for more than two weeks"

--- a/src/components/Auth/EmailVerifier.tsx
+++ b/src/components/Auth/EmailVerifier.tsx
@@ -65,6 +65,7 @@ const EmailVerifier = ({
               : Button.Type.DISABLED
           }
           size={Button.Size.LG}
+          canShrink={false}
           title={
             emailVerification.emailVerifyStatus === EMAIL_VERIFY_STATUS.IDLE
               ? signInputTranslation.sendEmail[language]

--- a/src/components/Common/BottomSheet.tsx
+++ b/src/components/Common/BottomSheet.tsx
@@ -74,12 +74,22 @@ export const BottomSheet = ({
   return (
     <BottomSheetContext.Provider value={{ position }}>
       {isOpen && isFixedBackground && (
-        <div
-          className="fixed w-screen h-screen top-0 bottom-0 left-0 right-0 bg-[rgba(0,0,0,0.3)] z-40"
-          onClick={() => {
-            if (isExitable) setIsShowBottomSheet?.(false);
-          }}
-        />
+        <>
+          <div
+            className="fixed top-0 left-0 w-screen"
+            style={{
+              height: 'env(safe-area-inset-top)',
+              backgroundColor: 'rgba(0,0,0,0.3)',
+              zIndex: 40,
+            }}
+          />
+          <div
+            className="fixed w-screen h-screen top-0 bottom-0 left-0 right-0 bg-[rgba(0,0,0,0.3)] z-40"
+            onClick={() => {
+              if (isExitable) setIsShowBottomSheet?.(false);
+            }}
+          />
+        </>
       )}
       <motion.div
         drag="y"

--- a/src/components/Common/Button.test.tsx
+++ b/src/components/Common/Button.test.tsx
@@ -21,7 +21,7 @@ describe('Button', () => {
     test.each(testCases)(
       '$type 타입 버튼이 올바른 스타일로 렌더링되어야 한다.',
       ({ type, expectedClass }) => {
-        render(<Button type={type} title={type} />);
+        render(<Button type={type} title={type} size={Button.Size.LG} />);
         const button = screen.getByRole('button', { name: type });
         expect(button).toHaveClass(expectedClass);
       },
@@ -29,7 +29,7 @@ describe('Button', () => {
 
     it('children으로 복잡한 JSX 요소를 전달해도 올바르게 렌더링해야 한다.', () => {
       render(
-        <Button type={buttonTypeKeys.PRIMARY}>
+        <Button type={buttonTypeKeys.PRIMARY} size={Button.Size.LG}>
           <div data-testid="child-container">
             <CallIcon />
             <span>전화걸기</span>
@@ -52,6 +52,7 @@ describe('Button', () => {
       render(
         <Button
           type={buttonTypeKeys.PRIMARY}
+          size={Button.Size.LG}
           title="Click me"
           onClick={handleClick}
         />,
@@ -72,7 +73,7 @@ describe('Button', () => {
     test.each(interactiveTypes)(
       'disabled 또는 inactive 타입이 아닌 버튼은 클릭/터치 시 style.transform scale이 변화해야 한다.',
       async (type) => {
-        render(<Button type={type} title={type} />);
+        render(<Button type={type} title={type} size={Button.Size.LG} />);
         const button = screen.getByRole('button', { name: type });
 
         // 초기 상태에는 transform이 적용되지 않음 (framer-motion 최적화)
@@ -100,7 +101,7 @@ describe('Button', () => {
     test.each(nonInteractiveTypes)(
       'disabled 또는 inactive 타입 버튼은 클릭/터치해도 style.transform scale이 변화하지 않아야 한다.',
       (type) => {
-        render(<Button type={type} title={type} />);
+        render(<Button type={type} title={type} size={Button.Size.LG} />);
         const button = screen.getByRole('button', { name: type });
 
         // 비활성 버튼은 항상 transform: none 상태를 유지
@@ -116,7 +117,9 @@ describe('Button', () => {
 
       const { rerender } = render(
         <Button
+          size={Button.Size.LG}
           type={buttonTypeKeys.DISABLED}
+          isFullWidth
           title="Disabled"
           onClick={handleClick}
         />,
@@ -126,7 +129,9 @@ describe('Button', () => {
 
       rerender(
         <Button
+          size={Button.Size.LG}
           type={buttonTypeKeys.INACTIVE}
+          isFullWidth
           title="Inactive"
           onClick={handleClick}
         />,

--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -17,6 +17,7 @@ type ButtonProps = {
   size: ButtonSize; // 버튼의 크기 (md, lg), 지정하지 않으면 type에 따른 기본 스타일 적용
   layout?: ButtonLayoutVariant; // 레이아웃 variant (두 버튼 배치 시 크기 조정용)
   isFullWidth?: boolean; // 버튼의 너비를 100%로 설정할지 여부
+  canShrink?: boolean; // 버튼의 크기를 줄일지 여부
   title?: string; // 버튼에 포함되는 글자 (optional)
   onClick?: () => void; // 클릭 이벤트 핸들러 (optional)
   children?: ReactNode; // 버튼 내부에 렌더링될 요소. title보다 우선순위가 높음(optional)
@@ -27,6 +28,7 @@ const Button = ({
   size,
   layout = ButtonLayoutVariant.DEFAULT,
   isFullWidth,
+  canShrink = true,
   title,
   onClick,
   children,
@@ -61,9 +63,9 @@ const Button = ({
   const getLayoutStyle = () => {
     switch (layout) {
       case ButtonLayoutVariant.SMALL_BUTTON:
-        return 'w-[31vw] py-4 rounded-xl button-16-semibold flex-shrink-0';
+        return `w-[31vw] py-4 rounded-xl button-16-semibold flex-shrink-0`;
       case ButtonLayoutVariant.FLEX_BUTTON:
-        return 'w-full py-4 rounded-xl button-16-semibold';
+        return `w-full py-4 rounded-xl button-16-semibold`;
       case ButtonLayoutVariant.DEFAULT:
       default:
         return '';
@@ -72,7 +74,6 @@ const Button = ({
 
   const getButtonStyle = () => {
     switch (type) {
-      // 기존 BACK, CONTINUE 타입은 deprecated로 남겨두되 layout으로 처리
       case buttonTypeKeys.PRIMARY:
         return 'bg-brand-500 text-text-strong';
       case buttonTypeKeys.NEUTRAL:
@@ -83,17 +84,18 @@ const Button = ({
         return 'bg-neutral-300 text-text-disabled';
       case buttonTypeKeys.INACTIVE:
         return 'text-text-disabled';
-      default: // 기본값으로 large type 적용
-        return 'w-full px-5 py-4 rounded-xl button-16-semibold';
+      default: // 기본값으로 NEUTRAL type 적용
+        return 'bg-neutral-100 text-text-strong';
     }
   };
 
   const getButtonStyleBySize = () => {
+    const shrinkStyle = canShrink ? '' : 'flex-shrink-0';
     switch (size) {
       case 'md':
-        return 'px-4 py-3 rounded-xl button-14-semibold flex-shrink-0';
+        return `px-4 py-3 rounded-xl button-14-semibold ${shrinkStyle}`;
       case 'lg':
-        return 'px-5 py-4 rounded-xl button-16-semibold flex-shrink-0';
+        return `px-5 py-4 rounded-xl button-16-semibold ${shrinkStyle}`;
     }
   };
 

--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -4,8 +4,10 @@ import {
   buttonTypeKeys,
   buttonTypeUnion,
 } from '@/constants/components';
-  import { ReactNode } from 'react';
-  import PressOverlay, { PressStrength } from '@/components/Common/PressedOverlay';
+import { ReactNode } from 'react';
+import PressOverlay, {
+  PressStrength,
+} from '@/components/Common/PressedOverlay';
 import { motion } from 'framer-motion';
 import { usePress } from '@/hooks/usePress';
 
@@ -54,24 +56,20 @@ const Button = ({
   };
 
   const baseButtonStyle =
-    'flex justify-center items-center relative overflow-hidden flex-shrink-0';
+    'flex justify-center items-center relative overflow-hidden';
 
   const getButtonStyle = () => {
     switch (type) {
       case buttonTypeKeys.LARGE:
         return 'w-full py-4 rounded-xl button-16-semibold';
-      case buttonTypeKeys.SMALL:
-        return 'w-[24vw] py-3 rounded-lg button-14-semibold';
       case buttonTypeKeys.APPLY:
         return `w-full py-4 rounded-xl bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
       case buttonTypeKeys.SMALLAPPLY: // 스크랩 버튼과 함께 쓰이는 Apply 버튼
-        return `w-[71vw] py-4 rounded-lg bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
+        return `w-full py-4 rounded-lg bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
       case buttonTypeKeys.BACK: // CONTINUE 버튼과 같은 열에 사용
         return 'w-[31vw] py-4 rounded-xl button-16-semibold flex-shrink-0';
       case buttonTypeKeys.CONTINUE: // BACK 버튼과 같은 열에 사용
         return 'w-full py-4 rounded-xl button-16-semibold';
-      case buttonTypeKeys.SCRAP:
-        return 'p-4 rounded-lg bg-[rgba(244,244,249,0.5)]';
       case buttonTypeKeys.PRIMARY:
         return 'bg-brand-500 text-text-strong';
       case buttonTypeKeys.NEUTRAL:
@@ -90,9 +88,9 @@ const Button = ({
   const getButtonStyleBySize = () => {
     switch (size) {
       case 'md':
-        return 'px-4 py-3 rounded-xl button-14-semibold';
+        return 'px-4 py-3 rounded-xl button-14-semibold flex-shrink-0';
       case 'lg':
-        return 'px-5 py-4 rounded-xl button-16-semibold';
+        return 'px-5 py-4 rounded-xl button-16-semibold flex-shrink-0';
     }
   };
 

--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -1,5 +1,6 @@
 import ScrapIcon from '@/assets/icons/Scrap.svg?react';
 import {
+  ButtonLayoutVariant,
   ButtonSize,
   buttonTypeKeys,
   buttonTypeUnion,
@@ -13,10 +14,9 @@ import { usePress } from '@/hooks/usePress';
 
 type ButtonProps = {
   type: buttonTypeUnion; // 버튼의 시맨틱 타입 (e.g., PRIMARY, NEUTRAL, DISABLED)
-  size?: ButtonSize; // 버튼의 크기 (md, lg), 지정하지 않으면 type에 따른 기본 스타일 적용
+  size: ButtonSize; // 버튼의 크기 (md, lg), 지정하지 않으면 type에 따른 기본 스타일 적용
+  layout?: ButtonLayoutVariant; // 레이아웃 variant (두 버튼 배치 시 크기 조정용)
   isFullWidth?: boolean; // 버튼의 너비를 100%로 설정할지 여부
-  bgColor?: string; // 버튼의 배경색 (optional)
-  fontColor?: string; // 버튼 글자색 (optional)
   title?: string; // 버튼에 포함되는 글자 (optional)
   onClick?: () => void; // 클릭 이벤트 핸들러 (optional)
   children?: ReactNode; // 버튼 내부에 렌더링될 요소. title보다 우선순위가 높음(optional)
@@ -25,9 +25,8 @@ type ButtonProps = {
 const Button = ({
   type,
   size,
+  layout = ButtonLayoutVariant.DEFAULT,
   isFullWidth,
-  bgColor,
-  fontColor,
   title,
   onClick,
   children,
@@ -58,18 +57,22 @@ const Button = ({
   const baseButtonStyle =
     'flex justify-center items-center relative overflow-hidden';
 
+  // 레이아웃 variant에 따른 스타일 반환
+  const getLayoutStyle = () => {
+    switch (layout) {
+      case ButtonLayoutVariant.SMALL_BUTTON:
+        return 'w-[31vw] py-4 rounded-xl button-16-semibold flex-shrink-0';
+      case ButtonLayoutVariant.FLEX_BUTTON:
+        return 'w-full py-4 rounded-xl button-16-semibold';
+      case ButtonLayoutVariant.DEFAULT:
+      default:
+        return '';
+    }
+  };
+
   const getButtonStyle = () => {
     switch (type) {
-      case buttonTypeKeys.LARGE:
-        return 'w-full py-4 rounded-xl button-16-semibold';
-      case buttonTypeKeys.APPLY:
-        return `w-full py-4 rounded-xl bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
-      case buttonTypeKeys.SMALLAPPLY: // 스크랩 버튼과 함께 쓰이는 Apply 버튼
-        return `w-full py-4 rounded-lg bg-neutral-100 bg-cover bg-center button-16-semibold text-neutral-100`;
-      case buttonTypeKeys.BACK: // CONTINUE 버튼과 같은 열에 사용
-        return 'w-[31vw] py-4 rounded-xl button-16-semibold flex-shrink-0';
-      case buttonTypeKeys.CONTINUE: // BACK 버튼과 같은 열에 사용
-        return 'w-full py-4 rounded-xl button-16-semibold';
+      // 기존 BACK, CONTINUE 타입은 deprecated로 남겨두되 layout으로 처리
       case buttonTypeKeys.PRIMARY:
         return 'bg-brand-500 text-text-strong';
       case buttonTypeKeys.NEUTRAL:
@@ -99,7 +102,7 @@ const Button = ({
       <motion.button
         className={`${
           size && getButtonStyleBySize()
-        } ${baseButtonStyle} ${getButtonStyle()} ${bgColor} ${fontColor} ${
+        } ${baseButtonStyle} ${getLayoutStyle()} ${getButtonStyle()} ${
           isFullWidth ? 'w-full' : ''
         }`}
         initial={{
@@ -130,5 +133,6 @@ const Button = ({
 
 Button.Type = buttonTypeKeys;
 Button.Size = ButtonSize;
+Button.Layout = ButtonLayoutVariant;
 
 export default Button;

--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -63,9 +63,9 @@ const Button = ({
   const getLayoutStyle = () => {
     switch (layout) {
       case ButtonLayoutVariant.SMALL_BUTTON:
-        return `w-[31vw] py-4 rounded-xl button-16-semibold flex-shrink-0`;
+        return `w-[31vw] flex-shrink-0`;
       case ButtonLayoutVariant.FLEX_BUTTON:
-        return `w-full py-4 rounded-xl button-16-semibold`;
+        return `w-full`;
       case ButtonLayoutVariant.DEFAULT:
       default:
         return '';
@@ -93,7 +93,7 @@ const Button = ({
     const shrinkStyle = canShrink ? '' : 'flex-shrink-0';
     switch (size) {
       case 'md':
-        return `px-4 py-3 rounded-xl button-14-semibold ${shrinkStyle}`;
+        return `px-4 py-3 rounded-lg button-14-semibold ${shrinkStyle}`;
       case 'lg':
         return `px-5 py-4 rounded-xl button-16-semibold ${shrinkStyle}`;
     }

--- a/src/components/Common/CompleteButtonModal.tsx
+++ b/src/components/Common/CompleteButtonModal.tsx
@@ -1,6 +1,5 @@
 import CheckIconLarge from '@/assets/icons/checkIconLarge.svg?react';
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 import useBodyScrollLock from '@/hooks/useBodyScrollLock';
 
 type CompleteButtonModalProps = {
@@ -24,9 +23,9 @@ const CompleteButtonModal = ({
       <div className="heading-20-semibold">{title}</div>
       <div className="body-14-regular">{content}</div>
       <Button
-        type={buttonTypeKeys.LARGE}
-        bgColor="bg-[#FEF387]"
-        fontColor="text-[#1E1926]"
+        type={Button.Type.PRIMARY}
+        size={Button.Size.LG}
+        isFullWidth
         title={buttonContent}
         onClick={onClick}
       />

--- a/src/components/Common/VisaSelectBottomSheet.tsx
+++ b/src/components/Common/VisaSelectBottomSheet.tsx
@@ -1,5 +1,4 @@
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 import { useUserStore } from '@/store/user';
 import { UserType } from '@/constants/user';
 import { VisaInfo } from '@/constants/post';
@@ -76,16 +75,17 @@ const VisaSelectBottomSheet = ({
         variant={BottomSheet.ButtonGroupVariant.TWO_HORIZONTAL}
       >
         <Button
-          type={buttonTypeKeys.BACK}
-          bgColor="bg-surface-secondary"
-          fontColor="text-text-strong"
+          type={Button.Type.NEUTRAL}
+          layout={Button.Layout.SMALL_BUTTON}
+          size={Button.Size.LG}
           title={buttonTranslation.reset[isEmployerByAccountType(account_type)]}
           onClick={handleReset}
         />
         <Button
-          type={buttonTypeKeys.CONTINUE}
-          bgColor="bg-surface-primary"
-          fontColor="text-text-strong"
+          type={Button.Type.PRIMARY}
+          layout={Button.Layout.FLEX_BUTTON}
+          isFullWidth
+          size={Button.Size.LG}
           title={
             buttonTranslation.selectComplete[
               isEmployerByAccountType(account_type)

--- a/src/components/Document/write/ValidatedSubmitButton.tsx
+++ b/src/components/Document/write/ValidatedSubmitButton.tsx
@@ -61,6 +61,7 @@ const ValidatedSubmitButton = <T extends FieldValues>({
     disabled: !isValid,
     isFullWidth: true,
     size: Button.Size.LG,
+    layout: Button.Layout.FLEX_BUTTON,
     type: isValid ? Button.Type.PRIMARY : Button.Type.DISABLED,
     style: {
       ...(children.props?.style || {}),

--- a/src/components/Employer/ApplicantDetail/EmployerApplicantDetailButton.tsx
+++ b/src/components/Employer/ApplicantDetail/EmployerApplicantDetailButton.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { useState } from 'react';
 import EmployerApplicantContactBottomSheet from '@/components/Employer/ApplicantDetail/EmployerApplicantContactBottomSheet';
@@ -24,9 +23,9 @@ const EmployerApplicantDetailButton = ({
       case 1:
         return (
           <Button
-            type={buttonTypeKeys.LARGE}
-            bgColor={'bg-primary-normal'}
-            fontColor="text-surface-invert"
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="이력서 확인하기"
             onClick={() =>
               navigate(`/employer/applicant/${applicant_id}/resume/accept`)
@@ -37,9 +36,9 @@ const EmployerApplicantDetailButton = ({
         return (
           <>
             <Button
-              type={buttonTypeKeys.LARGE}
-              bgColor={'bg-primary-normal'}
-              fontColor="text-surface-invert"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title="면접 일정 조율하기"
               onClick={() => setIsShowBottomSheet(true)}
             />
@@ -52,9 +51,9 @@ const EmployerApplicantDetailButton = ({
       case 3:
         return (
           <Button
-            type={buttonTypeKeys.APPLY}
-            bgColor={'bg-primary-normal'}
-            fontColor="text-surface-invert"
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="신청 서류 확인하기"
             onClick={() =>
               navigate(`/employer/applicant/document-detail/${applicant_id}`)
@@ -64,9 +63,9 @@ const EmployerApplicantDetailButton = ({
       case 4:
         return (
           <Button
-            type={buttonTypeKeys.APPLY}
-            bgColor={'bg-primary-normal'}
-            fontColor="text-surface-invert"
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="신청 서류 확인하기"
             onClick={() =>
               navigate(`/employer/applicant/document-detail/${applicant_id}`)
@@ -76,9 +75,9 @@ const EmployerApplicantDetailButton = ({
       case 5:
         return (
           <Button
-            type={buttonTypeKeys.APPLY}
-            bgColor={'bg-primary-normal'}
-            fontColor="text-surface-invert"
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="신청 서류 확인하기"
             onClick={() =>
               navigate(`/employer/applicant/document-detail/${applicant_id}`)
@@ -88,9 +87,9 @@ const EmployerApplicantDetailButton = ({
       case 6:
         return (
           <Button
-            type={buttonTypeKeys.APPLY}
-            bgColor={'bg-primary-normal'}
-            fontColor="text-surface-invert"
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="신청 서류 확인하기"
             onClick={() =>
               navigate(`/employer/applicant/document-detail/${applicant_id}`)
@@ -100,9 +99,9 @@ const EmployerApplicantDetailButton = ({
       case 7:
         return (
           <Button
-            type={buttonTypeKeys.APPLY}
-            bgColor={'bg-primary-normal'}
-            fontColor="text-surface-invert"
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="신청 서류 확인하기"
             onClick={() =>
               navigate(`/employer/applicant/document-detail/${applicant_id}`)
@@ -112,9 +111,9 @@ const EmployerApplicantDetailButton = ({
       default:
         return (
           <Button
-            type={buttonTypeKeys.APPLY}
-            bgColor={'bg-primary-neutral'}
-            fontColor="text-text-disabled"
+            type={Button.Type.NEUTRAL}
+            size={Button.Size.LG}
+            isFullWidth
             title={
               step === APPLICATION_STEP.PENDING
                 ? '2주 이상 대기 중입니다.'

--- a/src/components/Employer/ApplicantResumeAccept/EmployerApplicantResumeButton.tsx
+++ b/src/components/Employer/ApplicantResumeAccept/EmployerApplicantResumeButton.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { useNavigate, useParams } from 'react-router-dom';
 import { usePatchResumeAccepted } from '@/hooks/api/useApplication';
@@ -26,16 +25,17 @@ const EmployerApplicantResumeButton = () => {
     <BottomButtonPanel>
       <div className="w-full flex gap-2">
         <Button
-          type={buttonTypeKeys.BACK}
-          bgColor="bg-surface-secondary"
-          fontColor="text-text-normal"
+          type={Button.Type.NEUTRAL}
+          layout={Button.Layout.SMALL_BUTTON}
+          size={Button.Size.LG}
           title="거절"
           onClick={() => onClickAcceptButton(false)}
         />
         <Button
-          type={buttonTypeKeys.CONTINUE}
-          bgColor="bg-surface-primary"
-          fontColor="text-text-normal"
+          type={Button.Type.PRIMARY}
+          layout={Button.Layout.FLEX_BUTTON}
+          size={Button.Size.LG}
+          isFullWidth
           title="수락"
           onClick={() => onClickAcceptButton(true)}
         />

--- a/src/components/Employer/EmployeeSearch/EmployerEmployeeSearchFilterBottomSheet.tsx
+++ b/src/components/Employer/EmployeeSearch/EmployerEmployeeSearchFilterBottomSheet.tsx
@@ -1,5 +1,4 @@
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 import { useEffect, useState } from 'react';
 import {
   EMPLOYEE_SEARCH_CATEGORY_KO,
@@ -93,16 +92,17 @@ const EmployerEmployeeSearchFilterBottomSheet = ({
         variant={BottomSheet.ButtonGroupVariant.TWO_HORIZONTAL}
       >
         <Button
-          type={buttonTypeKeys.BACK}
-          bgColor="bg-surface-secondary"
-          fontColor="text-text-strong"
+          type={Button.Type.NEUTRAL}
+          layout={Button.Layout.SMALL_BUTTON}
+          size={Button.Size.LG}
           title={'초기화'}
           onClick={handleReset}
         />
         <Button
-          type={buttonTypeKeys.CONTINUE}
-          bgColor="bg-surface-primary"
-          fontColor="text-text-strong"
+          type={Button.Type.PRIMARY}
+          layout={Button.Layout.FLEX_BUTTON}
+          size={Button.Size.LG}
+          isFullWidth
           title={'적용하기'}
           onClick={handleSubmit}
         />

--- a/src/components/Employer/PostCreate/Step1.tsx
+++ b/src/components/Employer/PostCreate/Step1.tsx
@@ -53,7 +53,12 @@ const Step1 = ({ onNext }: { onNext: () => void }) => {
           validationFn={validatePostInfo}
           onClick={() => onNext()}
         >
-          <Button title="다음" isFullWidth type={Button.Type.PRIMARY} />
+          <Button
+            title="다음"
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            layout={Button.Layout.FLEX_BUTTON}
+          />
         </ValidatedSubmitButton>
       </BottomButtonPanel>
     </div>

--- a/src/components/Employer/PostCreate/Step2.tsx
+++ b/src/components/Employer/PostCreate/Step2.tsx
@@ -2,7 +2,6 @@ import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import InputLayout from '@/components/WorkExperience/InputLayout';
 import { JobPostingForm } from '@/types/postCreate/postCreate';
-import { buttonTypeKeys } from '@/constants/components';
 import ValidatedSubmitButton from '@/components/Document/write/ValidatedSubmitButton';
 import { Path } from 'react-hook-form';
 import { renderField } from '@/components/Document/write/renderField';
@@ -59,9 +58,9 @@ const Step2 = ({
           {/* 정보 입력 시마다 유효성을 검사해 모든 값이 유효하면 버튼이 활성화 */}
           <div className="w-full flex gap-2">
             <Button
-              type={buttonTypeKeys.BACK}
-              bgColor="bg-surface-secondary"
-              fontColor="text-text-normal"
+              type={Button.Type.NEUTRAL}
+              layout={Button.Layout.SMALL_BUTTON}
+              size={Button.Size.LG}
               title="이전"
               onClick={() => onPrev()}
             />
@@ -72,7 +71,7 @@ const Step2 = ({
               validationFn={validatePostInfo}
               onClick={() => onNext()}
             >
-              <Button title="다음" type={Button.Type.DISABLED} />
+              <Button title="다음" type={Button.Type.DISABLED} size={Button.Size.LG} />
             </ValidatedSubmitButton>
           </div>
         </BottomButtonPanel>

--- a/src/components/Employer/PostCreate/Step3.tsx
+++ b/src/components/Employer/PostCreate/Step3.tsx
@@ -54,9 +54,9 @@ const Step3 = ({
       <BottomButtonPanel>
         <div className="w-full flex gap-2">
           <Button
-            type={buttonTypeKeys.BACK}
-            bgColor="bg-surface-secondary"
-            fontColor="text-text-normal"
+            type={Button.Type.NEUTRAL}
+            layout={Button.Layout.SMALL_BUTTON}
+            size={Button.Size.LG}
             title="이전"
             onClick={() => onPrev()}
           />
@@ -65,7 +65,7 @@ const Step3 = ({
             validationFn={validatePostInfo}
             onClick={() => onNext()}
           >
-            <Button title="다음" type={Button.Type.LARGE} />
+            <Button title="다음" type={Button.Type.DISABLED} size={Button.Size.LG} />
           </ValidatedSubmitButton>
         </div>
       </BottomButtonPanel>

--- a/src/components/Employer/PostCreate/Step3.tsx
+++ b/src/components/Employer/PostCreate/Step3.tsx
@@ -1,7 +1,6 @@
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import InputLayout from '@/components/WorkExperience/InputLayout';
-import { buttonTypeKeys } from '@/constants/components';
 import {
   POST_REQUIRED_FIELDS,
   PostFormField,

--- a/src/components/Employer/PostCreate/Step4.tsx
+++ b/src/components/Employer/PostCreate/Step4.tsx
@@ -1,7 +1,6 @@
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import InputLayout from '@/components/WorkExperience/InputLayout';
-import { buttonTypeKeys } from '@/constants/components';
 import {
   POST_REQUIRED_FIELDS,
   PostFormField,
@@ -63,9 +62,9 @@ const Step4 = ({
       <BottomButtonPanel>
         <div className="w-full flex gap-2">
           <Button
-            type={buttonTypeKeys.BACK}
-            bgColor="bg-[#F4F4F9]"
-            fontColor="text-text-normal"
+            type={Button.Type.NEUTRAL}
+            layout={Button.Layout.SMALL_BUTTON}
+            size={Button.Size.LG}
             title="이전"
             onClick={() => onPrev()}
           />
@@ -74,7 +73,7 @@ const Step4 = ({
             validationFn={validatePostInfo}
             onClick={() => onNext()}
           >
-            <Button type={Button.Type.LARGE} title="다음" />
+            <Button type={Button.Type.DISABLED} title="다음" size={Button.Size.LG} />
           </ValidatedSubmitButton>
         </div>
       </BottomButtonPanel>

--- a/src/components/Employer/PostCreate/Step5.tsx
+++ b/src/components/Employer/PostCreate/Step5.tsx
@@ -1,7 +1,6 @@
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
 import InputLayout from '@/components/WorkExperience/InputLayout';
-import { buttonTypeKeys } from '@/constants/components';
 import {
   POST_REQUIRED_FIELDS,
   PostFormField,
@@ -61,9 +60,9 @@ const Step5 = ({
       <BottomButtonPanel>
         <div className="w-full flex gap-2">
           <Button
-            type={buttonTypeKeys.BACK}
-            bgColor="bg-surface-secondary"
-            fontColor="text-text-normal"
+            type={Button.Type.NEUTRAL}
+            layout={Button.Layout.SMALL_BUTTON}
+            size={Button.Size.LG}
             title="이전"
             onClick={() => onPrev()}
           />
@@ -72,7 +71,7 @@ const Step5 = ({
             validationFn={validatePostInfo}
             onClick={handleSubmit}
           >
-            <Button type={Button.Type.LARGE} title="완료" />
+            <Button type={Button.Type.DISABLED} title="완료" size={Button.Size.LG} />
           </ValidatedSubmitButton>
         </div>
       </BottomButtonPanel>

--- a/src/components/Employer/PostDetail/EmployerPostDetailButton.tsx
+++ b/src/components/Employer/PostDetail/EmployerPostDetailButton.tsx
@@ -1,5 +1,4 @@
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 import { useState } from 'react';
 import EmployerPostDeleteBottomSheet from '@/components/Employer/PostDetail/EmployerPostDeleteBottomSheet';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -15,16 +14,17 @@ const EmployerPostDetailButton = () => {
       <BottomButtonPanel>
         <div className="w-full flex justify-center gap-2 z-20">
           <Button
-            type={buttonTypeKeys.BACK}
-            bgColor="bg-surface-secondary"
-            fontColor="text-text-normal"
+            type={Button.Type.NEUTRAL}
+            layout={Button.Layout.SMALL_BUTTON}
+            size={Button.Size.LG}
             title="삭제"
             onClick={() => setIsOpenDeleteBottomSheet(true)}
           />
           <Button
-            type={buttonTypeKeys.CONTINUE}
-            bgColor="bg-surface-primary"
-            fontColor="text-text-normal"
+            type={Button.Type.PRIMARY}
+            layout={Button.Layout.FLEX_BUTTON}
+            size={Button.Size.LG}
+            isFullWidth
             title="편집"
             onClick={() =>
               navigate(`/employer/post/edit/${id}`, {

--- a/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerLaborContractForm.tsx
@@ -108,9 +108,9 @@ const EmployerLaborContractForm = ({
             onClick={handleSubmit(handleNext)}
           >
             <Button
-              type="large"
-              bgColor="bg-surface-primary"
-              fontColor="text-text-strong"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title={'작성완료'}
             />
           </ValidatedSubmitButton>

--- a/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
+++ b/src/components/Employer/WriteDocument/EmployerPartTimePermitForm.tsx
@@ -105,9 +105,9 @@ const EmployerPartTimePermitForm = ({
             onClick={handleSubmit(handleNext)}
           >
             <Button
-              type="large"
-              bgColor="bg-surface-primary"
-              fontColor="text-text-strong"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title={'작성완료'}
             />
           </ValidatedSubmitButton>

--- a/src/components/Information/AddressStep.tsx
+++ b/src/components/Information/AddressStep.tsx
@@ -35,6 +35,9 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
     setIsAddressSearch(false);
   };
 
+  const isAddressValid =
+    newAddress.address_detail && newAddress.address_detail?.trim().length <= 50;
+
   return (
     <div className="w-full mx-auto">
       <div className="w-full flex flex-row items-center justify-between">
@@ -104,29 +107,15 @@ const AddressStep = ({ userInfo, onNext }: AddressStepProps) => {
       {/* 다음 step 이동 버튼 포함한 Bottom Panel */}
       <BottomButtonPanel>
         <Button
-          type="large"
-          bgColor={
-            newAddress.address_detail &&
-            newAddress.address_detail?.trim().length > 50
-              ? 'bg-[#F4F4F9]'
-              : 'bg-[#fef387]'
-          }
-          fontColor={
-            newAddress.address_detail &&
-            newAddress.address_detail?.trim().length > 50
-              ? ''
-              : 'text-[#222]'
-          }
+          type={isAddressValid ? Button.Type.PRIMARY : Button.Type.DISABLED}
+          size={Button.Size.LG}
+          isFullWidth
           title="Next"
-          onClick={
-            newAddress.address_detail &&
-            newAddress.address_detail?.trim().length > 50
-              ? undefined
-              : () =>
-                  onNext({
-                    ...userInfo,
-                    address: newAddress,
-                  })
+          onClick={() =>
+            onNext({
+              ...userInfo,
+              address: newAddress,
+            })
           }
         />
       </BottomButtonPanel>

--- a/src/components/Information/InformationStep.tsx
+++ b/src/components/Information/InformationStep.tsx
@@ -40,7 +40,7 @@ const InformationStep = ({
   const [newUserInfo, setNewUserInfo] = useState<UserInfo>(initialUserInfo);
   // 버튼 활성화 여부를 위한 플래그
   const [isInvalid, setIsInvalid] = useState(true);
-  // 세 부분으로 나누어 입력받는 방식을 위해 전화번호만 별도의 state로 분리, 추후 유효성 검사 단에서 통합
+  // 두 부분으로 나누어 입력받는 방식을 위해 전화번호만 별도의 state로 분리, 추후 유효성 검사 단에서 통합
   const [phoneNum, setPhoneNum] = useState({
     start: '010',
     rest: '',
@@ -97,8 +97,6 @@ const InformationStep = ({
   };
 
   const handleNextClick = () => {
-    if (isInvalid) return;
-
     const formattedUserInfo = formatUserInfoForSubmission(
       newUserInfo,
       formatPhoneNumber(phoneNum),
@@ -215,9 +213,9 @@ const InformationStep = ({
         {/* 정보 입력 시마다 유효성을 검사해 모든 값이 유효하면 버튼이 활성화 */}
         <BottomButtonPanel>
           <Button
-            type="large"
-            bgColor={isInvalid ? 'bg-[#F4F4F9]' : 'bg-[#fef387]'}
-            fontColor={isInvalid ? '' : 'text-[#222]'}
+            type={isInvalid ? Button.Type.DISABLED : Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="Next"
             onClick={handleNextClick}
           />

--- a/src/components/Information/LanguageStep.tsx
+++ b/src/components/Information/LanguageStep.tsx
@@ -42,15 +42,11 @@ const LanguageStep = ({ onNext }: LanguageStepProps) => {
       {/* 다음 step 이동 버튼 포함한 Bottom Panel */}
       <BottomButtonPanel>
         <Button
-          type="large"
-          bgColor={language === '' ? 'bg-[#F4F4F9]' : 'bg-[#fef387]'}
-          fontColor={language === '' ? '' : 'text-[#222]'}
+          type={language === '' ? Button.Type.DISABLED : Button.Type.PRIMARY}
+          size={Button.Size.LG}
+          isFullWidth
           title="Next"
-          onClick={
-            language === ''
-              ? undefined
-              : () => onNext(language.toUpperCase() as Language)
-          }
+          onClick={() => onNext(language.toUpperCase() as Language)}
         />
       </BottomButtonPanel>
     </div>

--- a/src/components/ManageResume/BookmarkContactPanel.tsx
+++ b/src/components/ManageResume/BookmarkContactPanel.tsx
@@ -1,5 +1,4 @@
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 import BookmarkIcon from '@/assets/icons/BookmarkIcon.svg?react';
 import BookmarkCheckedIcon from '@/assets/icons/BookmarkCheckedIcon.svg?react';
 import { useUserStore } from '@/store/user';
@@ -54,9 +53,9 @@ const BookmarkContactPanel = ({
             </button>
           )}
           <Button
-            type={buttonTypeKeys.APPLY}
-            bgColor={'bg-surface-primary'}
-            fontColor={'text-text-strong'}
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title="연락하기"
             onClick={onClickApply}
           />

--- a/src/components/PostApply/PostApplyButton.tsx
+++ b/src/components/PostApply/PostApplyButton.tsx
@@ -47,16 +47,16 @@ const PostApplyButton = () => {
       <BottomButtonPanel>
         <section className="w-full flex gap-2">
           <Button
-            type={Button.Type.BACK}
-            bgColor="bg-surface-secondary"
-            fontColor="text-text-normal"
+            type={Button.Type.NEUTRAL}
+            size={Button.Size.LG}
+            layout={Button.Layout.SMALL_BUTTON}
             title="Edit"
             onClick={() => navigate('/profile/manage-resume')}
           />
           <Button
             type={Button.Type.PRIMARY}
             size={Button.Size.LG}
-            isFullWidth
+            layout={Button.Layout.FLEX_BUTTON}
             title="Apply Now"
             onClick={onClickApply}
           />

--- a/src/components/PostSearchFilter/PostSearchFilterBottomSheet.tsx
+++ b/src/components/PostSearchFilter/PostSearchFilterBottomSheet.tsx
@@ -72,18 +72,18 @@ const PostSearchFilterBottomSheet = ({
         variant={BottomSheet.ButtonGroupVariant.TWO_VERTICAL}
       >
         <Button
-          type={Button.Type.BACK}
-          bgColor="bg-surface-secondary"
-          fontColor="text-text-normal button-16-semibold"
+          type={Button.Type.NEUTRAL}
+          size={Button.Size.LG}
+          layout={Button.Layout.SMALL_BUTTON}
           title={
             postSearchTranslation.reset[isEmployerByAccountType(account_type)]
           }
           onClick={onClickReset}
         />
         <Button
-          type={Button.Type.CONTINUE}
-          bgColor="bg-surface-primary"
-          fontColor="text-text-normal button-16-semibold"
+          type={Button.Type.PRIMARY}
+          size={Button.Size.LG}
+          layout={Button.Layout.FLEX_BUTTON}
           title={
             postSearchTranslation.apply[isEmployerByAccountType(account_type)]
           }

--- a/src/components/PostSearchFilter/PostSearchFilterButtons.tsx
+++ b/src/components/PostSearchFilter/PostSearchFilterButtons.tsx
@@ -1,4 +1,3 @@
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { PostSearchFilterItemType } from '@/types/PostSearchFilter/PostSearchFilterItem';
 import { initialFilterList } from '@/constants/postSearch';
@@ -24,16 +23,17 @@ const PostSearchFilterButtons = ({
   return (
     <section className="w-full flex justify-center items-center gap-2 pt-3 pb-10 px-6">
       <Button
-        type={buttonTypeKeys.BACK}
-        bgColor="bg-surface-secondary"
-        fontColor="text-text-normal button-16-semibold"
+        type={Button.Type.NEUTRAL}
+        layout={Button.Layout.SMALL_BUTTON}
+        size={Button.Size.LG}
         title={buttonTranslation.reset[isEmployerByAccountType(account_type)]}
         onClick={onClickReset}
       />
       <Button
-        type={buttonTypeKeys.CONTINUE}
-        bgColor="bg-surface-primary"
-        fontColor="text-text-strong button-16-semibold"
+        type={Button.Type.PRIMARY}
+        layout={Button.Layout.FLEX_BUTTON}
+        size={Button.Size.LG}
+        isFullWidth
         title={buttonTranslation.apply[isEmployerByAccountType(account_type)]}
         onClick={onClickApply}
       />

--- a/src/components/Profile/Password/CurrentPasswordStep.tsx
+++ b/src/components/Profile/Password/CurrentPasswordStep.tsx
@@ -67,7 +67,7 @@ const CurrentPasswordStep = ({
             onChange={onPasswordChange}
             canDelete={false}
           />
-          {error && <p className="text-[#FF6F61] text-xs p-2">{error}</p>}
+          {error && <p className="text-text-error text-xs p-2">{error}</p>}
         </InputLayout>
         <div className="flex flex-col gap-4 px-4 pb-4 bg-white rounded-md">
           <div className="flex flex-col divide-y divide-gray-200"></div>
@@ -75,21 +75,19 @@ const CurrentPasswordStep = ({
         <BottomButtonPanel>
           <div className="w-full">
             <Button
-              type="large"
-              bgColor={
+              type={
                 password?.length > 0
-                  ? 'bg-surface-primary'
-                  : 'bg-surface-secondary'
+                  ? Button.Type.PRIMARY
+                  : Button.Type.DISABLED
               }
-              fontColor={
-                password?.length > 0 ? 'text-text-normal' : 'text-text-disabled'
-              }
+              size={Button.Size.LG}
+              isFullWidth
               title={
                 signInputTranslation.continue[
                   isEmployerByAccountType(account_type)
                 ]
               }
-              onClick={password?.length > 0 ? onSubmit : undefined}
+              onClick={onSubmit}
             />
           </div>
         </BottomButtonPanel>

--- a/src/components/Profile/Password/NewPasswordStep.tsx
+++ b/src/components/Profile/Password/NewPasswordStep.tsx
@@ -79,7 +79,7 @@ const NewPasswordStep = ({
               canDelete={false}
             />
             {newPasswordError && (
-              <p className="text-[#FF6F61] text-xs p-2">{newPasswordError}</p>
+              <p className="text-text-error text-xs p-2">{newPasswordError}</p>
             )}
           </InputLayout>
           <InputLayout
@@ -101,7 +101,7 @@ const NewPasswordStep = ({
               canDelete={false}
             />
             {confirmPasswordError && (
-              <p className="text-[#FF6F61] text-xs p-2">
+              <p className="text-text-error text-xs p-2">
                 {confirmPasswordError}
               </p>
             )}
@@ -114,15 +114,15 @@ const NewPasswordStep = ({
         <BottomButtonPanel>
           <div className="w-full">
             <Button
-              type="large"
-              bgColor={isValid ? 'bg-surface-primary' : 'bg-surface-secondary'}
-              fontColor={isValid ? 'text-text-normal' : 'text-text-disabled'}
+              type={isValid ? Button.Type.PRIMARY : Button.Type.DISABLED}
+              size={Button.Size.LG}
+              isFullWidth
               title={
                 signInputTranslation.continue[
                   isEmployerByAccountType(account_type)
                 ]
               }
-              onClick={isValid ? onSubmit : undefined}
+              onClick={onSubmit}
             />
           </div>
         </BottomButtonPanel>

--- a/src/components/Profile/Password/SuccessStep.tsx
+++ b/src/components/Profile/Password/SuccessStep.tsx
@@ -24,9 +24,9 @@ const SuccessStep = () => {
         <BottomButtonPanel>
           <div className="w-full">
             <Button
-              type="large"
-              bgColor={'bg-surface-primary'}
-              fontColor={'text-text-normal'}
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title={signInputTranslation.continue[userLanguage]}
               onClick={signout}
             />

--- a/src/components/Signup/VerificationSuccessful.tsx
+++ b/src/components/Signup/VerificationSuccessful.tsx
@@ -27,9 +27,9 @@ const VerificationSuccessful = ({
       <BottomButtonPanel>
         <div className="w-full">
           <Button
-            type="large"
-            bgColor={'bg-surface-primary'}
-            fontColor={'text-text-normal'}
+            type={Button.Type.PRIMARY}
+            size={Button.Size.LG}
+            isFullWidth
             title={buttonText}
             onClick={onNext}
           />

--- a/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
+++ b/src/components/WriteDocuments/IntegratedApplicationWriteForm.tsx
@@ -155,9 +155,9 @@ const IntegratedApplicationWriteForm = ({
             onClick={handleSubmit(handleNext)}
           >
             <Button
-              type="large"
-              bgColor="bg-surface-primary"
-              fontColor="text-text-strong"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title={isEdit ? 'Modify' : 'Create'}
             />
           </ValidatedSubmitButton>

--- a/src/components/WriteDocuments/LaborContractWriteForm.tsx
+++ b/src/components/WriteDocuments/LaborContractWriteForm.tsx
@@ -136,9 +136,9 @@ const LaborContractWriteForm = ({
             onClick={handleSubmit(handleNext)}
           >
             <Button
-              type="large"
-              bgColor="bg-surface-primary"
-              fontColor="text-text-strong"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title={'Complete'}
             />
           </ValidatedSubmitButton>

--- a/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
+++ b/src/components/WriteDocuments/PartTimePermitWriteForm.tsx
@@ -135,9 +135,9 @@ const PartTimePermitWriteForm = ({
             onClick={handleSubmit(handleNext)}
           >
             <Button
-              type="large"
-              bgColor="bg-surface-primary"
-              fontColor="text-text-strong"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title={'Complete'}
             />
           </ValidatedSubmitButton>

--- a/src/constants/components.ts
+++ b/src/constants/components.ts
@@ -21,3 +21,10 @@ export enum ButtonSize {
   MD = 'md',
   LG = 'lg',
 }
+
+// 레이아웃 variant 추가
+export enum ButtonLayoutVariant {
+  DEFAULT = 'default',
+  SMALL_BUTTON = 'small-button', // 기존 BACK 타입 대체
+  FLEX_BUTTON = 'flex-button', // 기존 CONTINUE 타입 대체
+}

--- a/src/pages/ApplicationDetail/ApplicationDetailSchoolPage.tsx
+++ b/src/pages/ApplicationDetail/ApplicationDetailSchoolPage.tsx
@@ -8,7 +8,6 @@ import useNavigateBack from '@/hooks/useNavigateBack';
 import RecruiterIcon from '@/assets/icons/ApplicationDetail/RecruiterIcon.svg?react';
 import { useParams } from 'react-router-dom';
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 import LoadingPostItem from '@/components/Common/LoadingPostItem';
 import EmptyJobIcon from '@/assets/icons/EmptyJobIcon.svg?react';
 import { handleGoExternalWeb } from '@/utils/application';
@@ -128,16 +127,16 @@ const ApplicationDetailSchoolPage = () => {
           </main>
           <footer className="w-full pt-3 pb-9 px-4 flex flex-col gap-2">
             <Button
-              type={buttonTypeKeys.LARGE}
-              bgColor={'bg-primary-normal'}
-              fontColor="text-surface-invert"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title={'Go to next step'}
               onClick={handleClickNextStep}
             />
             <Button
-              type={buttonTypeKeys.LARGE}
-              bgColor={'bg-primary-neutral'}
-              fontColor="text-surface-invert"
+              type={Button.Type.NEUTRAL}
+              size={Button.Size.LG}
+              isFullWidth
               title={'Maybe later'}
               onClick={handleBackButtonClick}
             />

--- a/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
+++ b/src/pages/ApplicationDocuments/ApplicationDocumentsPage.tsx
@@ -78,17 +78,13 @@ const ApplicationDocumentsPage = () => {
                 {!isComplete && (
                   <BottomButtonPanel>
                     <Button
-                      type="large"
-                      bgColor={
+                      type={
                         isDocumentComplete(data?.data)
-                          ? 'bg-surface-primary'
-                          : 'bg-surface-secondary'
+                          ? Button.Type.PRIMARY
+                          : Button.Type.DISABLED
                       }
-                      fontColor={
-                        isDocumentComplete(data?.data)
-                          ? 'text-text-normal'
-                          : 'text-text-disabled'
-                      }
+                      size={Button.Size.LG}
+                      isFullWidth
                       title="Completed"
                       {...(isDocumentComplete(data?.data) && {
                         onClick: () => submitDocuments(Number(currentPostId)),

--- a/src/pages/ApplicationResult/ApplicationResultPage.tsx
+++ b/src/pages/ApplicationResult/ApplicationResultPage.tsx
@@ -2,7 +2,6 @@ import BaseHeader from '@/components/Common/Header/BaseHeader';
 import RadioButton from '@/components/Information/RadioButton';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { buttonTypeKeys } from '@/constants/components';
 import Button from '@/components/Common/Button';
 import { usePatchHiKoreaResult } from '@/hooks/api/useApplication';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
@@ -75,9 +74,9 @@ const ApplicationResultPage = () => {
       </main>
       <BottomButtonPanel>
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={'bg-primary-normal'}
-          fontColor="text-surface-invert"
+          type={Button.Type.PRIMARY}
+          size={Button.Size.LG}
+          isFullWidth
           title="Submit result"
           onClick={onClickRegistration}
         />

--- a/src/pages/EditProfile/EditProfilePage.tsx
+++ b/src/pages/EditProfile/EditProfilePage.tsx
@@ -4,7 +4,6 @@ import BaseHeader from '@/components/Common/Header/BaseHeader';
 import Input from '@/components/Common/Input';
 import RadioButton from '@/components/Information/RadioButton';
 import EditProfilePicture from '@/components/Profile/EditProfilePicture';
-import { buttonTypeKeys } from '@/constants/components';
 import { GenderType } from '@/constants/profile';
 import {
   InitialUserProfileDetail,
@@ -299,10 +298,10 @@ const EditProfilePage = () => {
 
           <BottomButtonPanel>
             <Button
-              type={buttonTypeKeys.LARGE}
+              type={isValid ? Button.Type.PRIMARY : Button.Type.DISABLED}
+              size={Button.Size.LG}
+              isFullWidth
               title="Save"
-              bgColor={isValid ? 'bg-[#FEF387]' : 'bg-[#F4F4F9]'}
-              fontColor={isValid ? 'text-[#1E1926]' : 'text-[#BDBDBD]'}
               onClick={isValid ? handleSubmit : undefined}
             />
           </BottomButtonPanel>

--- a/src/pages/Employer/EditProfile/EmployerEditProfilePage.tsx
+++ b/src/pages/Employer/EditProfile/EmployerEditProfilePage.tsx
@@ -82,9 +82,9 @@ const EmployerEditProfilePage = () => {
       />
       <BottomButtonPanel>
         <Button
-          type="large"
-          bgColor={isValid ? 'bg-surface-primary' : 'bg-surface-secondary'}
-          fontColor={isValid ? 'text-text-normal' : 'text-text-disabled'}
+          type={isValid ? Button.Type.PRIMARY : Button.Type.DISABLED}
+          size={Button.Size.LG}
+          isFullWidth
           title="수정 완료"
           onClick={handleSubmit}
         />

--- a/src/pages/LanguageSetting/LanguageSettingPage.tsx
+++ b/src/pages/LanguageSetting/LanguageSettingPage.tsx
@@ -39,9 +39,9 @@ const LanguageSettingPage = () => {
       </div>
       <BottomButtonPanel>
         <Button
-          type="large"
-          bgColor="bg-[#FEF387]"
-          fontColor="text-[##1E1926]"
+          type={Button.Type.PRIMARY}
+          size={Button.Size.LG}
+          isFullWidth
           title="Save"
           onClick={handleSaveButton}
         />

--- a/src/pages/Resume/IntroductionPage.tsx
+++ b/src/pages/Resume/IntroductionPage.tsx
@@ -3,7 +3,6 @@ import Button from '@/components/Common/Button';
 import BaseHeader from '@/components/Common/Header/BaseHeader';
 import PageTitle from '@/components/Common/PageTitle';
 import IntroductionInput from '@/components/Introduction/IntroductionInput';
-import { buttonTypeKeys } from '@/constants/components';
 import { usePatchIntroduction } from '@/hooks/api/useResume';
 import useNavigateBack from '@/hooks/useNavigateBack';
 import { IntroductionRequest } from '@/types/api/resumes';
@@ -79,9 +78,9 @@ const IntroductionPage = () => {
       />
       <BottomButtonPanel>
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={isValid ? 'bg-surface-primary' : 'bg-surface-disabled'}
-          fontColor={isValid ? 'text-text-strong' : 'text-text-disabled'}
+          type={isValid ? Button.Type.PRIMARY : Button.Type.DISABLED}
+          size={Button.Size.LG}
+          isFullWidth
           title="Save"
           onClick={isValid ? handleSubmit : undefined}
         />

--- a/src/pages/Resume/WorkPreferencePage.tsx
+++ b/src/pages/Resume/WorkPreferencePage.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import BaseHeader from '@/components/Common/Header/BaseHeader';
 import BottomButtonPanel from '@/components/Common/BottomButtonPanel';
 import Button from '@/components/Common/Button';
-import { buttonTypeKeys } from '@/constants/components';
 import {
   useGetWorkPreference,
   usePutWorkPreference,
@@ -160,9 +159,7 @@ const WorkPreferencePage = () => {
       />
 
       <div className="p-4 flex flex-col [&>*:last-child]:mb-24">
-        <InputLayout
-          title="Select one or multiple areas where you want to work"
-        >
+        <InputLayout title="Select one or multiple areas where you want to work">
           <div className="w-full flex flex-col gap-2">
             <div onClick={() => handleAreaSelectOpen()}>
               <Dropdown
@@ -197,9 +194,7 @@ const WorkPreferencePage = () => {
           </div>
         </InputLayout>
         <Divider />
-        <InputLayout
-          title="What kind of job are you looking for?"
-        >
+        <InputLayout title="What kind of job are you looking for?">
           <WorkPreferenceJobTypeSelect
             selectedJobTypes={selectedJobTypes}
             onJobTypesChange={handleJobTypesChange}
@@ -216,9 +211,9 @@ const WorkPreferencePage = () => {
 
       <BottomButtonPanel>
         <Button
-          type={buttonTypeKeys.LARGE}
-          bgColor={isFormValid ? 'bg-surface-primary' : 'bg-surface-disabled'}
-          fontColor={isFormValid ? 'text-text-strong' : 'text-text-disabled'}
+          type={isFormValid ? Button.Type.PRIMARY : Button.Type.DISABLED}
+          size={Button.Size.LG}
+          isFullWidth
           title="Save"
           onClick={handleSubmit}
         />

--- a/src/pages/WriteDocuments/RequestModifyPage.tsx
+++ b/src/pages/WriteDocuments/RequestModifyPage.tsx
@@ -59,9 +59,9 @@ const RequestModifyPage = () => {
           </InputLayout>
           <BottomButtonPanel>
             <Button
-              type="large"
-              bgColor="bg-[#FEF387]"
-              fontColor="text-[#1E1926]"
+              type={Button.Type.PRIMARY}
+              size={Button.Size.LG}
+              isFullWidth
               title="Request"
               onClick={() => {
                 sendRequest({ id: Number(id), reason: reasonInput });


### PR DESCRIPTION
## Related issue 🛠

- closed #457 

## Work Description ✏️
<div align="center"><img width="320" height="668" alt="스크린샷 2025-07-17 오후 8 38 15" src="https://github.com/user-attachments/assets/1c600e9d-a901-469c-a8fd-403b978160d0" /><img width="321" height="667" alt="스크린샷 2025-07-17 오후 8 38 30" src="https://github.com/user-attachments/assets/ebe40912-3788-442e-a435-3af3fff499f5" />
</div>

### `Button` 컴포넌트 레이아웃 시스템 개선
- 기존 구 버전 `Button` 컴포넌트의 레이아웃 깨짐 현상 수정
- `layout` prop 추가로 버튼 배치 방식 개선
  - `ButtonLayoutVariant.SMALL_BUTTON`: 기존 BACK 타입 대체 (w-[31vw], flex-shrink-0)
  - `ButtonLayoutVariant.FLEX_BUTTON`: 기존 CONTINUE 타입 대체 (w-full)
  - `ButtonLayoutVariant.DEFAULT`: 기본값
- `canShrink` prop 추가로 flex-shrink 적용 여부 제어 가능
- 구 버전 button 클래스 제거 및 새로운 레이아웃 시스템 적용

### 서비스 전반 Button 컴포넌트 마이그레이션
- 프로젝트 전반 38개 파일에서 Button 컴포넌트 사용법 통일
- 기존 `Button.Type.BACK/Button.Type.CONTINUE` → `layout` prop 사용으로 변경
- 두 버튼 배치 시 일관된 레이아웃 적용 (SMALL_BUTTON + FLEX_BUTTON 조합)

### BottomSheet 컴포넌트 UX 개선
- 바텀시트 등장 시 status bar 영역 dim 처리 추가
- viewport-fit=cover 메타태그와 연동하여 안전 영역까지 dim 적용

### 테스트 코드 업데이트
- `BookmarkContactPanel.test.tsx` `Button` 컴포넌트 변경사항 반영
- `Button` 컴포넌트 유닛 테스트에 `layout` prop 테스트 케이스 추가

## Uncompleted Tasks 😅

N/A

## To Reviewers 📢
- Button 컴포넌트 리뉴얼을 진행하면서 구 버전 클래스명을 사용하고 있던 몇몇 곳의 ui에 문제가 생겨 이를 해결하는 김에 미루고 미뤘던 Button 컴포넌트 리뉴얼을 완료했습니다.
- 기존 `BACK`, `CONTINUE`, `APPLY` 등으로 목적마다 다르게 스타일을 정의해 사용하던 구 클래스명들을 전부 enum 기반의 layout, style, size 의 get 함수 3개를 통해 원하는대로 조합해 사용할 수 있게 변경되었습니다.
- 디자인 측에서 요청한 BottomSheet 출현 시 status-bar 영역 dim 처리도 적용해봤는데, dev branch에 배포 후 앱에서 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 버튼 레이아웃을 위한 새로운 enum(ButtonLayoutVariant) 추가로 다양한 버튼 레이아웃 지원.

* **버그 수정**
  * 일부 기기에서 노치/라운드 코너 영역까지 화면이 확장되도록 뷰포트 설정 개선.
  * BottomSheet 오버레이가 안전 영역까지 덮도록 시각적 개선.

* **리팩터**
  * 전체 버튼 컴포넌트의 스타일 및 타입 지정 방식을 enum 기반의 표준화된 API로 변경.
  * 배경색, 폰트색 등 수동 스타일 지정 방식 제거 및 size, layout, isFullWidth 등 명확한 속성 사용.
  * 버튼의 크기(size) 명시 및 레이아웃(layout) 속성 도입, canShrink 등 옵션 추가.
  * 여러 페이지와 컴포넌트에서 버튼 스타일 및 사용 방식 일관성 확보.

* **테스트**
  * 버튼 컴포넌트 및 관련 패널 테스트 코드의 prop 반영 및 테스트 명확성 개선.

* **문서화/스타일**
  * 일부 에러 메시지 색상 클래스 명확화 및 주석 보완.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->