### PR TITLE
Fix/463 - bottomsheet 스크롤 버그

### DIFF
--- a/src/components/Common/BottomSheet.test.tsx
+++ b/src/components/Common/BottomSheet.test.tsx
@@ -266,7 +266,7 @@ describe('BottomSheetContent', () => {
       expect(screen.getByText('내용')).toBeInTheDocument();
     });
 
-    it('isMaxHeight가 true일 때 max-height 클래스가 적용되어야 한다', () => {
+    it('isMaxHeight가 true일 때 h-full 클래스가 적용되어야 한다', () => {
       render(
         <BottomSheetContent isMaxHeight={true}>
           <div>내용</div>
@@ -274,10 +274,10 @@ describe('BottomSheetContent', () => {
       );
 
       const contentContainer = screen.getByText('내용').parentElement;
-      expect(contentContainer).toHaveClass('max-h-[49vh]');
+      expect(contentContainer).toHaveClass('h-full');
     });
 
-    it('isMaxHeight가 false일 때 h-full 클래스가 적용되어야 한다', () => {
+    it('isMaxHeight가 false일 때 max-height 클래스가 적용되어야 한다', () => {
       render(
         <BottomSheetContent isMaxHeight={false}>
           <div>내용</div>
@@ -285,8 +285,8 @@ describe('BottomSheetContent', () => {
       );
 
       const contentContainer = screen.getByText('내용').parentElement;
-      expect(contentContainer).toHaveClass('h-full');
-      expect(contentContainer).not.toHaveClass('max-h-[49vh]');
+      expect(contentContainer).toHaveClass('max-h-[49vh]');
+      expect(contentContainer).not.toHaveClass('h-full');
     });
   });
 });

--- a/src/components/Common/BottomSheet.tsx
+++ b/src/components/Common/BottomSheet.tsx
@@ -114,7 +114,6 @@ export const BottomSheet = ({
         style={{
           top: `${viewHeight - contentHeight - LAYOUT_MARGIN}px`,
         }}
-        onClick={(e) => e.stopPropagation()}
       >
         <div ref={contentRef} className="flex flex-col h-auto">
           {children}
@@ -184,7 +183,10 @@ export const BottomSheetContent = ({
 }) => {
   return (
     <div
-      className={`overflow-y-scroll overflow-x-hidden px-5 ${isMaxHeight ? 'max-h-[49vh]' : 'h-full'}`}
+      className={`overflow-y-scroll overflow-x-hidden px-5 ${isMaxHeight ? 'h-full' : 'max-h-[49vh]'}`}
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onPointerMove={(e) => e.stopPropagation()}
     >
       {children}
     </div>

--- a/src/components/Common/Dropdown.tsx
+++ b/src/components/Common/Dropdown.tsx
@@ -24,7 +24,7 @@ export const DropdownModal = ({
   onSelect: (option: string) => void;
 }) => {
   return (
-    <div className="flex-col max-h-[33.3rem] overflow-y-scroll no-scrollbar w-full relative rounded-[0.625rem] bg-white flex items-start justify-start px-1 text-left z-10">
+    <div className="flex-col max-h-[33.3rem] overflow-y-scroll overflow-x-hidden no-scrollbar w-full relative rounded-[0.625rem] bg-white flex items-start justify-start px-1 text-left z-10">
       <div className="flex-1 flex flex-col w-full items-start gap-[5px]">
         {/* 각 옵션을 매핑하여 표시합니다. */}
         {options.map((option) => (


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #463 

## Work Description ✏️
<div align="center">좌: 개선 전  &nbsp  우 : 개선 후</div>
<div align="center"><img width="320" src="https://github.com/user-attachments/assets/db36e299-205c-418a-aedd-93b82a503572" /><img width="320" src="https://github.com/user-attachments/assets/1c3c66d5-083b-494c-8b35-262de08cfcfa" /></div>


- 작업 내용
  - `BottomSheet` 내부 횡이동 방지
  - `BottomSheet` 내 터치 스크롤 시 닫히는 현상 수정

## Uncompleted Tasks 😅

## To Reviewers 📢
- 이벤트 버블링 현상으로 인해 발생한 버그이며, `onPointerDown`, `onPointerMove` 속성에 `stopPropagation`을 매핑해 해결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * BottomSheet에서 이벤트 전파 차단 위치를 내부 컨테이너로 이동하고, 높이 스타일 적용 방식을 수정했습니다.
  * Dropdown에서 가로 방향 오버플로우가 숨겨져, 가로 스크롤이나 넘침 현상이 발생하지 않도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->