### PR TITLE
[Feat/468]  카드 컴포넌트 레이아웃 및 태그 스타일 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
 
 > https://youtu.be/PfW00paozHM?si=0qIEgXpjnI9DGKZO
 
+## DeepWiki
+
+> https://deepwiki.com/Team-inglo/Giggle-Web
+
 ## Tech Stack
 
 <p>

--- a/src/components/Application/ApplicationCardList.tsx
+++ b/src/components/Application/ApplicationCardList.tsx
@@ -34,8 +34,8 @@ const ApplicationCardList = ({
     return (
       <div className="mt-10 flex flex-col justify-center items-center gap-1">
         <EmptyJobIcon />
-        <h3 className="heading-20-semibold text-[#252525]">No results found</h3>
-        <p className="body-14-regular text-[#9397A1] text-center">
+        <h3 className="heading-20-semibold text-text-strong">No results found</h3>
+        <p className="body-14-regular text-text-alternative text-center">
           We couldn’t find any jobs matching your search. <br />
           Try adjusting your filters!
         </p>

--- a/src/components/Application/ApplicationPostCard.tsx
+++ b/src/components/Application/ApplicationPostCard.tsx
@@ -14,48 +14,48 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="Application Success 🎉"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-[#0066FF]/10"
           color="text-text-success"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
     case APPLICATION_STEP.RESUME_REJECTED:
       return (
         <Tag
           value="Resume Rejected ⚠"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-[#FF5252]/10"
           color="text-text-error"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
     case APPLICATION_STEP.APPLICATION_REJECTED:
       return (
         <Tag
           value="Application Rejected ⚠"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-[#FF5252]/10"
           color="text-text-error"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
     default:
       return (
         <Tag
           value="Application in Progress 🔍"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-surface-secondary"
           color="text-text-normal"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
   }

--- a/src/components/Application/ApplicationPostCard.tsx
+++ b/src/components/Application/ApplicationPostCard.tsx
@@ -14,10 +14,10 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="Application Success 🎉"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
-          backgroundColor="bg-[#0066FF]/10"
+          backgroundColor="bg-status-success/10"
           color="text-text-success"
           fontStyle="caption-11-semibold"
         />
@@ -26,10 +26,10 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="Resume Rejected ⚠"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
-          backgroundColor="bg-[#FF5252]/10"
+          backgroundColor="bg-status-error/10"
           color="text-text-error"
           fontStyle="caption-11-semibold"
         />
@@ -38,10 +38,10 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="Application Rejected ⚠"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
-          backgroundColor="bg-[#FF5252]/10"
+          backgroundColor="bg-status-error/10"
           color="text-text-error"
           fontStyle="caption-11-semibold"
         />
@@ -50,7 +50,7 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="Application in Progress 🔍"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-surface-secondary"

--- a/src/components/Common/EmployeeCard/EmployeeCard.tsx
+++ b/src/components/Common/EmployeeCard/EmployeeCard.tsx
@@ -70,57 +70,58 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
   // Column 형 카드
   return (
     <article
-      className="w-[9.063rem] flex flex-col gap-2 rounded-lg"
+      className="flex flex-col gap-2 w-[152px] rounded-lg"
       onClick={goToResumeDetailPage}
     >
-      <div className="w-[9.063rem] h-[6.75rem] rounded-lg overflow-hidden border border-border-alternative">
+      <div className="flex flex-col gap-[12px]">
         {cardData?.profile_img_url ? (
-          <img
-            src={cardData.profile_img_url}
-            alt="profile"
-            className="object-cover w-full h-full"
-          />
+          <div className="relative w-[152px] h-[114px] overflow-hidden rounded-lg shrink-0">
+            <div
+              className="absolute inset-0 bg-cover bg-center"
+              style={{
+                backgroundImage: `url(${cardData.profile_img_url})`,
+              }}
+            />
+            <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
+          </div>
         ) : (
-          <div className="flex items-center justify-center w-full h-full text-white bg-gradient-to-r from-purple-500 to-pink-500">
-            No Image
+          <div className="relative w-[152px] h-[114px] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
+            <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
           </div>
         )}
-      </div>
-
-      <div className="flex flex-col">
-        <h3 className="button-16-semibold text-text-normal line-clamp-1 whitespace-normal pb-[0.125rem]">
-          {cardData?.name}
-        </h3>
-
-        <p className="caption-12-regular text-text-alternative line-clamp-2 whitespace-normal mb-2">
-          {cardData?.title || '친절한 서비스를 고객을 맞게 만들어보아요!'}
-        </p>
-
-        <div className="flex flex-wrap items-center justify-between gap-1">
-          <div className="flex flex-wrap items-center gap-1">
-            {cardData?.visa && (
-              <Tag
-                value={cardData.visa.replace(/_/g, '-')}
-                padding="py-[0.188rem] px-[0.25rem]"
-                isRounded={false}
-                hasCheckIcon={false}
-                backgroundColor="bg-surface-secondary"
-                color="text-text-alternative"
-                fontStyle="caption-12-regular"
-              />
-            )}
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-0.5">
+            <h3 className="button-16-semibold text-text-strong line-clamp-1 whitespace-normal max-h-42 min-h-0">
+              {cardData.name}
+            </h3>
+            <p className="caption-12-regular text-text-alternative line-clamp-2 whitespace-normal">
+              {cardData?.title}
+            </p>
           </div>
-
-          <EmployeeCardBookmark
-            isBookmarked={cardData?.is_bookmarked}
-            bookmarkCount={cardData?.bookmark_count}
-            onBookmarkClick={handleClickBookmark}
-            variant="with-count"
-          />
+          <div className="flex flex-wrap items-center justify-between gap-1">
+            <div className="flex flex-wrap items-center gap-1">
+              {cardData?.visa && (
+                <Tag
+                  value={cardData.visa?.replace(/_/g, '-')}
+                  padding="py-[3px] px-[5px]"
+                  isRounded={false}
+                  hasCheckIcon={false}
+                  backgroundColor="bg-surface-secondary"
+                  color="text-text-alternative"
+                  fontStyle="caption-11-semibold"
+                />
+              )}
+            </div>
+            <EmployeeCardBookmark
+              isBookmarked={cardData?.is_bookmarked}
+              bookmarkCount={cardData?.bookmark_count}
+              onBookmarkClick={handleClickBookmark}
+              variant="with-count"
+            />
+          </div>
         </div>
       </div>
     </article>
   );
-};
 
 export default EmployeeCard;

--- a/src/components/Common/EmployeeCard/EmployeeCard.tsx
+++ b/src/components/Common/EmployeeCard/EmployeeCard.tsx
@@ -123,5 +123,5 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
       </div>
     </article>
   );
-
+};
 export default EmployeeCard;

--- a/src/components/Common/EmployeeCard/EmployeeCard.tsx
+++ b/src/components/Common/EmployeeCard/EmployeeCard.tsx
@@ -46,7 +46,7 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
         <div className="pt-2 flex items-center gap-1 flex-wrap">
           <Tag
             value={cardData?.industry}
-            padding="py-[0.188rem] px-[0.25rem]"
+            padding="py-[0.188rem] px-[0.313rem]"
             isRounded={true}
             hasCheckIcon={false}
             backgroundColor="bg-status-blue-300/10"
@@ -55,7 +55,7 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
           />
           <Tag
             value={cardData?.visa?.replace(/_/g, '-')}
-            padding="py-[0.188rem] px-[0.25rem]"
+            padding="py-[0.188rem] px-[0.313rem]"
             isRounded={true}
             hasCheckIcon={false}
             backgroundColor="bg-surface-secondary"
@@ -70,12 +70,12 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
   // Column 형 카드
   return (
     <article
-      className="flex flex-col gap-2 w-[152px] rounded-lg"
+      className="flex flex-col gap-2 w-[9.5rem] rounded-lg"
       onClick={goToResumeDetailPage}
     >
-      <div className="flex flex-col gap-[12px]">
+      <div className="flex flex-col gap-3">
         {cardData?.profile_img_url ? (
-          <div className="relative w-[152px] h-[114px] overflow-hidden rounded-lg shrink-0">
+          <div className="relative w-[9.5rem] h-[7.125rem] overflow-hidden rounded-lg shrink-0">
             <div
               className="absolute inset-0 bg-cover bg-center"
               style={{
@@ -85,7 +85,7 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
             <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
           </div>
         ) : (
-          <div className="relative w-[152px] h-[114px] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
+          <div className="relative w-[9.5rem] h-[7.125rem] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
             <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
           </div>
         )}
@@ -103,7 +103,7 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
               {cardData?.visa && (
                 <Tag
                   value={cardData.visa?.replace(/_/g, '-')}
-                  padding="py-[3px] px-[5px]"
+                  padding="py-[0.188rem] px-[0.313rem]"
                   isRounded={false}
                   hasCheckIcon={false}
                   backgroundColor="bg-surface-secondary"

--- a/src/components/Common/JobPostingCard.tsx
+++ b/src/components/Common/JobPostingCard.tsx
@@ -79,11 +79,11 @@ const CardHeader = ({ isBookMarkButton }: { isBookMarkButton?: boolean }) => {
   };
 
   return (
-    <div className="w-full flex justify-between items-center">
+    <div className="w-full flex justify-between items-start">
       <h3 className="heading-18-semibold text-text-strong line-clamp-2">
         {title}
       </h3>
-      <div className="w-6 h-6">
+      <div className="w-6 h-6 mt-0.5">
         {account_type === UserType.USER && isBookMarkButton && (
           <button onClick={(e) => onClickBookmark(e)}>
             {is_book_marked ? <BookmarkCheckedIcon /> : <BookmarkIcon />}
@@ -98,9 +98,9 @@ const CardCompanyInfo = () => {
   const { company_name, summaries } = useCard();
 
   return (
-    <p className="caption-12-regular text-text-alternative whitespace-normal">
+    <p className="body-14-regular text-text-normal whitespace-normal flex items-center">
       {company_name}
-      <span className="mx-2 inline-block px-[0.063rem] h-3 bg-border-alternative align-middle"></span>
+      <span className="w-0.5 h-0.5 bg-border-normal rounded-full mx-1"></span>
       {summaries?.address?.split(' ')?.slice(0, 2)?.join(' ') ?? ''}
     </p>
   );
@@ -123,7 +123,7 @@ const CardVisa = () => {
   const { tags } = useCard();
 
   return (
-    <span className="caption-12-regular text-text-alternative whitespace-normal">
+    <span className="body-14-regular text-text-normal whitespace-normal items-center">
       {tags.visa.sort().join(', ').replace(/_/g, '-')}
     </span>
   );
@@ -139,7 +139,7 @@ const CardWorkDayInfo = () => {
       : summaries.work_period?.replace(/_/g, ' ').toLowerCase();
 
   return (
-    <span className="caption-12-regular text-text-alternative whitespace-normal">
+    <span className="body-14-regular text-text-normal whitespace-normal items-center">
       {workDaysPerWeekToText(
         summaries.work_days_per_week as string,
         account_type,
@@ -179,8 +179,8 @@ const CardTagList = () => {
         padding="pt-[3px] pb-[4px] px-[6px]"
         isRounded={true}
         hasCheckIcon={false}
-        backgroundColor="bg-surface-secondary"
-        color="text-text-normal"
+        backgroundColor="bg-[#0066FF1F]"
+        color="text-text-success"
         fontStyle="caption-12-semibold"
       />
     </div>

--- a/src/components/Common/JobPostingCard.tsx
+++ b/src/components/Common/JobPostingCard.tsx
@@ -56,10 +56,10 @@ const CardDeadLineTag = () => {
   return (
     <Tag
       value={formatRecruitmentDeadLine()}
-      padding="px-[5px] py-[3px]"
+      padding="px-[0.313rem] py-[0.188rem]"
       isRounded={false}
       hasCheckIcon={false}
-      backgroundColor="bg-[#FF5252]/10"
+      backgroundColor="bg-status-error/10"
       color="text-text-error"
       fontStyle="caption-11-semibold"
     />
@@ -161,7 +161,7 @@ const CardTagList = () => {
             ? EN_FILTER_CATEGORY_OPTIONS[tags.employment_type?.toLowerCase()]
             : tags.employment_type?.toLowerCase()
         }
-        padding="pt-[3px] pb-[4px] px-[6px]"
+        padding="pt-[0.188rem] pb-[0.25rem] px-[0.375rem]"
         isRounded={true}
         hasCheckIcon={false}
         backgroundColor="bg-surface-secondary"
@@ -176,10 +176,10 @@ const CardTagList = () => {
               ]
             : tags.job_category.replace(/_/g, ' ').toLowerCase()
         }
-        padding="pt-[3px] pb-[4px] px-[6px]"
+        padding="pt-[0.188rem] pb-[0.25rem] px-[0.375rem]"
         isRounded={true}
         hasCheckIcon={false}
-        backgroundColor="bg-[#0066FF1F]"
+        backgroundColor="bg-status-success/10"
         color="text-text-success"
         fontStyle="caption-12-semibold"
       />

--- a/src/components/Common/JobPostingCard.tsx
+++ b/src/components/Common/JobPostingCard.tsx
@@ -56,12 +56,12 @@ const CardDeadLineTag = () => {
   return (
     <Tag
       value={formatRecruitmentDeadLine()}
-      padding="px-1 py-[0.188rem]"
+      padding="px-[5px] py-[3px]"
       isRounded={false}
       hasCheckIcon={false}
       backgroundColor="bg-[#FF5252]/10"
       color="text-text-error"
-      fontStyle="caption-12-regular"
+      fontStyle="caption-11-semibold"
     />
   );
 };
@@ -161,12 +161,12 @@ const CardTagList = () => {
             ? EN_FILTER_CATEGORY_OPTIONS[tags.employment_type?.toLowerCase()]
             : tags.employment_type?.toLowerCase()
         }
-        padding="py-[0.188rem] px-[0.375rem]"
+        padding="pt-[3px] pb-[4px] px-[6px]"
         isRounded={true}
         hasCheckIcon={false}
         backgroundColor="bg-surface-secondary"
         color="text-text-normal"
-        fontStyle="caption-12-regular"
+        fontStyle="caption-12-semibold"
       />
       <Tag
         value={
@@ -176,12 +176,12 @@ const CardTagList = () => {
               ]
             : tags.job_category.replace(/_/g, ' ').toLowerCase()
         }
-        padding="py-[0.188rem] px-[0.375rem]"
+        padding="pt-[3px] pb-[4px] px-[6px]"
         isRounded={true}
         hasCheckIcon={false}
         backgroundColor="bg-surface-secondary"
         color="text-text-normal"
-        fontStyle="caption-12-regular"
+        fontStyle="caption-12-semibold"
       />
     </div>
   );

--- a/src/components/Common/Tag.tsx
+++ b/src/components/Common/Tag.tsx
@@ -27,7 +27,7 @@ const Tag = ({
 }: TagProps) => {
   return (
     <div
-      className={`w-fit h-fit flex items-center gap-[0.5rem] ${padding} ${backgroundColor} ${color} ${borderColor} ${borderColor ? 'border' : ''} ${fontStyle} ${isRounded ? 'rounded' : 'rounded-sm'}`}
+      className={`w-fit h-fit flex items-center gap-[0.5rem] ${padding} ${backgroundColor} ${color} ${borderColor} ${borderColor ? 'border' : ''} ${fontStyle} ${isRounded ? 'rounded-lg' : 'rounded-md'}`}
     >
       {hasCheckIcon && <Icon icon={TagCheckIcon} fillColor={color} />}
       {value}

--- a/src/components/Employer/ApplicantList/EmployerApplicantCard.tsx
+++ b/src/components/Employer/ApplicantList/EmployerApplicantCard.tsx
@@ -16,10 +16,10 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="채용을 완료했어요 🎉"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
-          backgroundColor="bg-[#0066FF]/10"
+          backgroundColor="bg-status-success/10"
           color="text-text-success"
           fontStyle="caption-11-semibold"
         />
@@ -28,10 +28,10 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="거절한 지원자에요 ⚠"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
-          backgroundColor="bg-[#FF5252]/10"
+          backgroundColor="bg-status-error/10"
           color="text-text-error"
           fontStyle="caption-11-semibold"
         />
@@ -40,10 +40,10 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="서류 재검토가 필요해요 ⚠"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
-          backgroundColor="bg-[#FF5252]/10"
+          backgroundColor="bg-status-error/10"
           color="text-text-error"
           fontStyle="caption-11-semibold"
         />
@@ -52,7 +52,7 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="진행 상황을 확인해보세요 ! 📋"
-          padding="px-[5px] py-[3px]"
+          padding="px-[0.313rem] py-[0.188rem]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-primary-normal"
@@ -84,7 +84,7 @@ const EmployerApplicantCard = ({
             {applicantData.nationality.replace(/_/g, ' ').toLowerCase()}
           </p>
         </div>
-        <p className=" caption-12-regular text-text-alternative">
+        <p className="caption-12-regular text-text-alternative">
           {applicantData?.duration_of_days}일 전
         </p>
       </div>

--- a/src/components/Employer/ApplicantList/EmployerApplicantCard.tsx
+++ b/src/components/Employer/ApplicantList/EmployerApplicantCard.tsx
@@ -16,48 +16,48 @@ const renderStatusBar = (status: ApplicationStepType) => {
       return (
         <Tag
           value="채용을 완료했어요 🎉"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-[#0066FF]/10"
           color="text-text-success"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
     case APPLICATION_STEP.RESUME_REJECTED:
       return (
         <Tag
           value="거절한 지원자에요 ⚠"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-[#FF5252]/10"
           color="text-text-error"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
     case APPLICATION_STEP.APPLICATION_REJECTED:
       return (
         <Tag
           value="서류 재검토가 필요해요 ⚠"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-[#FF5252]/10"
           color="text-text-error"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
     default:
       return (
         <Tag
           value="진행 상황을 확인해보세요 ! 📋"
-          padding="px-1 py-[0.188rem]"
+          padding="px-[5px] py-[3px]"
           isRounded={false}
           hasCheckIcon={false}
           backgroundColor="bg-primary-normal"
           color="text-text-normal"
-          fontStyle="caption-12-regular"
+          fontStyle="caption-11-semibold"
         />
       );
   }

--- a/src/components/Home/HomeCareerPostCard.tsx
+++ b/src/components/Home/HomeCareerPostCard.tsx
@@ -26,48 +26,50 @@ const HomeCareerPostCard = ({ careerData }: HomeCareerPostCardProps) => {
 
   return (
     <article
-      className="flex flex-col gap-2 w-[9.063rem] rounded-lg"
+      className="flex flex-col gap-2 w-[152px] rounded-lg"
       onClick={goToCareerDetailPage}
     >
-      {/* 이미지 박스 - 기존 Job 공고와 동일하게 통일 */}
-      {careerData.img_urls && careerData.img_urls.length > 0 ? (
-        <div
-          className="w-full h-[6.75rem] min-w-[9.063rem] rounded-lg border border-border-alternative bg-cover bg-center"
-          style={{
-            backgroundImage: `url(${careerData.img_urls[0]})`,
-          }}
-        ></div>
-      ) : (
-        <div className="w-full h-[6.75rem] min-w-[9.063rem] rounded-lg border border-border-alternative bg-surface-secondary flex items-center justify-center text-text-alternative">
-          No Image
-        </div>
-      )}
+      <div className="flex flex-col gap-[12px]">
+        {careerData.img_urls && careerData.img_urls.length > 0 ? (
+          <div className="relative w-[152px] h-[114px] overflow-hidden rounded-lg shrink-0">
+            <div
+              className="absolute inset-0 bg-cover bg-center"
+              style={{
+                backgroundImage: `url(${careerData.img_urls[0]})`,
+              }}
+            />
+            <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
+          </div>
+        ) : (
+          <div className="relative w-[152px] h-[114px] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
+            <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
+          </div>
+        )}
 
-      <div className="block">
-        {/* 제목 */}
-        <h3 className="whitespace-normal min-h-10 button-16-semibold text-text-normal line-clamp-2">
-          {careerData.title}
-        </h3>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-0.5">
+            <h3 className="button-16-semibold text-text-strong line-clamp-2 whitespace-normal max-h-42 min-h-0">
+              {careerData.title}
+            </h3>
+            <p className="caption-12-regular text-text-alternative whitespace-normal flex items-center">
+              {careerData.organizer_name ?? '-'}
+              <span className="w-px h-2.5 bg-border-alternative mx-1"></span>
+              {careerData.host_name ?? '-'}
+            </p>
+          </div>
 
-        {/* 주관-주최 */}
-        <p className="whitespace-normal caption-12-regular text-text-alternative">
-          {careerData.organizer_name ?? '-'}
-          <span className="inline-block h-3 mx-1 align-middle border bg-border-alternative"></span>
-          {careerData.host_name ?? '-'}
-        </p>
-
-        {/* 태그 영역 */}
-        <div className="flex flex-wrap items-center gap-1 mt-2">
-          {careerData.career_category && (
-            <span className="caption-12-regular bg-[#0066FF1F] text-text-success py-[0.188rem] px-[0.25rem] rounded">
-              {CAREER_CATEGORY[careerData.career_category]}
-            </span>
-          )}
-          {careerData.visa && careerData.visa.length > 0 && (
-            <span className="caption-12-regular bg-surface-secondary text-text-alternative py-[0.188rem] px-[0.25rem] rounded">
-              {RepresentedVisa}
-            </span>
-          )}
+          <div className="flex flex-wrap items-center gap-1">
+            {careerData.career_category && (
+              <span className="caption-12-regular bg-[#0066FF1F] text-text-success py-[0.188rem] px-[0.25rem] rounded">
+                {CAREER_CATEGORY[careerData.career_category]}
+              </span>
+            )}
+            {careerData.visa && careerData.visa.length > 0 && (
+              <span className="caption-12-regular bg-surface-secondary text-text-alternative py-[0.188rem] px-[0.25rem] rounded">
+                {RepresentedVisa}
+              </span>
+            )}
+          </div>
         </div>
       </div>
     </article>

--- a/src/components/Home/HomeCareerPostCard.tsx
+++ b/src/components/Home/HomeCareerPostCard.tsx
@@ -60,12 +60,12 @@ const HomeCareerPostCard = ({ careerData }: HomeCareerPostCardProps) => {
 
           <div className="flex flex-wrap items-center gap-1">
             {careerData.career_category && (
-              <span className="caption-12-regular bg-[#0066FF1F] text-text-success py-[0.188rem] px-[0.25rem] rounded">
+              <span className="caption-11-semibold bg-[#0066FF1F] text-text-success py-[3px] px-[5px] rounded-md">
                 {CAREER_CATEGORY[careerData.career_category]}
               </span>
             )}
             {careerData.visa && careerData.visa.length > 0 && (
-              <span className="caption-12-regular bg-surface-secondary text-text-alternative py-[0.188rem] px-[0.25rem] rounded">
+              <span className="caption-11-semibold bg-surface-secondary text-text-alternative py-[3px] px-[5px] rounded-md">
                 {RepresentedVisa}
               </span>
             )}

--- a/src/components/Home/HomeCareerPostCard.tsx
+++ b/src/components/Home/HomeCareerPostCard.tsx
@@ -26,12 +26,12 @@ const HomeCareerPostCard = ({ careerData }: HomeCareerPostCardProps) => {
 
   return (
     <article
-      className="flex flex-col gap-2 w-[152px] rounded-lg"
+      className="flex flex-col gap-2 w-[9.5rem] rounded-lg"
       onClick={goToCareerDetailPage}
     >
-      <div className="flex flex-col gap-[12px]">
+      <div className="flex flex-col gap-3">
         {careerData.img_urls && careerData.img_urls.length > 0 ? (
-          <div className="relative w-[152px] h-[114px] overflow-hidden rounded-lg shrink-0">
+          <div className="relative w-[9.5rem] h-[7.125rem] overflow-hidden rounded-lg shrink-0">
             <div
               className="absolute inset-0 bg-cover bg-center"
               style={{
@@ -41,7 +41,7 @@ const HomeCareerPostCard = ({ careerData }: HomeCareerPostCardProps) => {
             <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
           </div>
         ) : (
-          <div className="relative w-[152px] h-[114px] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
+          <div className="relative w-[9.5rem] h-[7.125rem] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
             <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
           </div>
         )}
@@ -60,12 +60,12 @@ const HomeCareerPostCard = ({ careerData }: HomeCareerPostCardProps) => {
 
           <div className="flex flex-wrap items-center gap-1">
             {careerData.career_category && (
-              <span className="caption-11-semibold bg-[#0066FF1F] text-text-success py-[3px] px-[5px] rounded-md">
+              <span className="caption-11-semibold bg-[#0066FF1F] text-text-success py-[0.188rem] px-[0.313rem] rounded-md">
                 {CAREER_CATEGORY[careerData.career_category]}
               </span>
             )}
             {careerData.visa && careerData.visa.length > 0 && (
-              <span className="caption-11-semibold bg-surface-secondary text-text-alternative py-[3px] px-[5px] rounded-md">
+              <span className="caption-11-semibold bg-surface-secondary text-text-alternative py-[0.188rem] px-[0.313rem] rounded-md">
                 {RepresentedVisa}
               </span>
             )}

--- a/src/components/Home/HomePostCard.tsx
+++ b/src/components/Home/HomePostCard.tsx
@@ -35,57 +35,67 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
 
   return (
     <article
-      className="flex flex-col gap-2 w-[9.063rem] rounded-lg"
+      className="flex flex-col gap-2 w-[152px] rounded-lg"
       onClick={goToPostDetailPage}
     >
-      {jobPostingData?.representative_img_url ? (
-        <div
-          className="w-full h-[6.75rem] min-w-[9.063rem] rounded-lg border border-border-alternative bg-cover bg-center"
-          style={{
-            backgroundImage: `url(${jobPostingData.representative_img_url})`,
-          }}
-        ></div>
-      ) : (
-        <div className="w-full h-[6.75rem] rounded-lg border border-border-alternative bg-surface-secondary"></div>
-      )}
-      <div className="block">
-        <h3 className="min-h-10 button-16-semibold text-text-normal line-clamp-2 whitespace-normal">
-          {jobPostingData.title}
-        </h3>
-        <p className="caption-12-regular text-text-alternative whitespace-normal">
-          {jobPostingData.company_name}
-          <span className="mx-1 inline-block align-middle border h-3 bg-border-alternative"></span>
-          {jobPostingData.summaries.address.split(' ').slice(0, 2).join(' ')}{' '}
-        </p>
-      </div>
-      <div className="flex items-center flex-wrap gap-1">
-        <Tag
-          value={
-            account_type === UserType.OWNER
-              ? EN_FILTER_CATEGORY_OPTIONS[
-                  jobPostingData.tags.employment_type.toLowerCase()
-                ]
-              : jobPostingData.tags.employment_type.toLowerCase()
-          }
-          padding="py-[0.188rem] px-[0.25rem]"
-          isRounded={false}
-          hasCheckIcon={false}
-          backgroundColor="bg-[#0066FF1F]"
-          color="text-text-success"
-          fontStyle="caption-12-regular"
-        />
-        <Tag
-          value={RepresentedVisa}
-          padding="py-[0.188rem] px-[0.25rem]"
-          isRounded={false}
-          hasCheckIcon={false}
-          backgroundColor="bg-surface-secondary"
-          color="text-text-alternative"
-          fontStyle="caption-12-regular"
-        />
+      <div className="flex flex-col gap-[12px]">
+        {jobPostingData?.representative_img_url ? (
+          <div className="relative w-[152px] h-[114px] overflow-hidden rounded-lg shrink-0">
+            <div
+              className="absolute inset-0 bg-cover bg-center"
+              style={{
+                backgroundImage: `url(${jobPostingData.representative_img_url})`,
+              }}
+            />
+            <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
+          </div>
+        ) : (
+          <div className="relative w-[152px] h-[114px] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
+            <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-0.5">
+            <h3 className="min-h-10 button-16-semibold text-text-normal line-clamp-2 whitespace-normal">
+              {jobPostingData.title}
+            </h3>
+            <p className="caption-12-regular text-text-alternative whitespace-normal">
+              {jobPostingData.company_name}
+              <span className="mx-1 inline-block align-middle border h-3 bg-border-alternative"></span>
+              {jobPostingData.summaries.address.split(' ').slice(0, 2).join(' ')}{' '}
+            </p>
+          </div>
+          <div className="flex items-center flex-wrap gap-1">
+            <Tag
+              value={
+                account_type === UserType.OWNER
+                  ? EN_FILTER_CATEGORY_OPTIONS[
+                      jobPostingData.tags.employment_type.toLowerCase()
+                    ]
+                  : jobPostingData.tags.employment_type.toLowerCase()
+              }
+              padding="py-[0.188rem] px-[0.25rem]"
+              isRounded={false}
+              hasCheckIcon={false}
+              backgroundColor="bg-[#0066FF1F]"
+              color="text-text-success"
+              fontStyle="caption-12-regular"
+            />
+            <Tag
+              value={RepresentedVisa}
+              padding="py-[0.188rem] px-[0.25rem]"
+              isRounded={false}
+              hasCheckIcon={false}
+              backgroundColor="bg-surface-secondary"
+              color="text-text-alternative"
+              fontStyle="caption-12-regular"
+            />
+          </div>
+        </div>
       </div>
     </article>
   );
 };
 
 export default HomePostCard;
+

--- a/src/components/Home/HomePostCard.tsx
+++ b/src/components/Home/HomePostCard.tsx
@@ -74,21 +74,21 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
                     ]
                   : jobPostingData.tags.employment_type.toLowerCase()
               }
-              padding="py-[0.188rem] px-[0.25rem]"
+              padding="py-[3px] px-[5px]"
               isRounded={false}
               hasCheckIcon={false}
               backgroundColor="bg-[#0066FF1F]"
               color="text-text-success"
-              fontStyle="caption-12-regular"
+              fontStyle="caption-11-semibold"
             />
             <Tag
               value={RepresentedVisa}
-              padding="py-[0.188rem] px-[0.25rem]"
+              padding="py-[3px] px-[5px]"
               isRounded={false}
               hasCheckIcon={false}
               backgroundColor="bg-surface-secondary"
               color="text-text-alternative"
-              fontStyle="caption-12-regular"
+              fontStyle="caption-11-semibold"
             />
           </div>
         </div>

--- a/src/components/Home/HomePostCard.tsx
+++ b/src/components/Home/HomePostCard.tsx
@@ -35,12 +35,12 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
 
   return (
     <article
-      className="flex flex-col gap-2 w-[152px] rounded-lg"
+      className="flex flex-col gap-2 w-[9.5rem] rounded-lg"
       onClick={goToPostDetailPage}
     >
-      <div className="flex flex-col gap-[12px]">
+      <div className="flex flex-col gap-3">
         {jobPostingData?.representative_img_url ? (
-          <div className="relative w-[152px] h-[114px] overflow-hidden rounded-lg shrink-0">
+          <div className="relative w-[9.5rem] h-[7.125rem] overflow-hidden rounded-lg shrink-0">
             <div
               className="absolute inset-0 bg-cover bg-center"
               style={{
@@ -50,7 +50,7 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
             <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
           </div>
         ) : (
-          <div className="relative w-[152px] h-[114px] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
+          <div className="relative w-[9.5rem] h-[7.125rem] bg-surface-secondary flex items-center justify-center rounded-lg shrink-0">
             <div className="absolute inset-0 border border-[#8F919D1A] rounded-lg pointer-events-none" />
           </div>
         )}
@@ -74,7 +74,7 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
                     ]
                   : jobPostingData.tags.employment_type.toLowerCase()
               }
-              padding="py-[3px] px-[5px]"
+              padding="py-[0.188rem] px-[0.313rem]"
               isRounded={false}
               hasCheckIcon={false}
               backgroundColor="bg-[#0066FF1F]"
@@ -83,7 +83,7 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
             />
             <Tag
               value={RepresentedVisa}
-              padding="py-[3px] px-[5px]"
+              padding="py-[0.188rem] px-[0.313rem]"
               isRounded={false}
               hasCheckIcon={false}
               backgroundColor="bg-surface-secondary"

--- a/src/components/Home/HomePostCard.tsx
+++ b/src/components/Home/HomePostCard.tsx
@@ -56,13 +56,13 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
         )}
         <div className="flex flex-col gap-2">
           <div className="flex flex-col gap-0.5">
-            <h3 className="min-h-10 button-16-semibold text-text-normal line-clamp-2 whitespace-normal">
+            <h3 className="button-16-semibold text-text-strong line-clamp-2 whitespace-normal max-h-42 min-h-0">
               {jobPostingData.title}
             </h3>
-            <p className="caption-12-regular text-text-alternative whitespace-normal">
+            <p className="caption-12-regular text-text-alternative whitespace-normal flex items-center">
               {jobPostingData.company_name}
-              <span className="mx-1 inline-block align-middle border h-3 bg-border-alternative"></span>
-              {jobPostingData.summaries.address.split(' ').slice(0, 2).join(' ')}{' '}
+              <span className="w-px h-2.5 bg-border-alternative mx-1"></span>
+              {jobPostingData.summaries.address.split(' ').slice(0, 2).join(' ')}
             </p>
           </div>
           <div className="flex items-center flex-wrap gap-1">
@@ -98,4 +98,3 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
 };
 
 export default HomePostCard;
-


### PR DESCRIPTION
## Related issue 🛠


## Work Description ✏️

카드 컴포넌트 간 레이아웃 불일치 및 태그 스타일 상이 이슈가 있어, 전체 카드 UI를 기준에 맞춰 통일했습니다.
(카드 컴포넌트 레이아웃 구조를 통일하고, Tag 스타일 조정 및 적용)
•	HomePostCard, HomeCareerPostCard, EmployeeCard : 이미지 및 텍스트 정렬, 레이아웃 통일
•	EmployeeCard: 상단 정보 정렬 및 padding 수정
•	Tag: rounded 값 및 spacing 일괄 정비 (디자인 시스템 반영)


## Uncompleted Tasks 😅

N/A

## To Reviewers 📢



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 카드 및 태그 컴포넌트의 패딩, 폰트 크기, 폰트 굵기, 테두리 반경 등 스타일이 전반적으로 개선되었습니다.
  * 이미지 및 텍스트 영역의 레이아웃이 정교하게 조정되어 카드의 시각적 완성도가 높아졌습니다.
  * 태그와 구분선, 배경, 정렬 등 세부적인 UI 요소의 디자인이 일관성 있게 변경되었습니다.

* **Refactor**
  * 이미지 및 텍스트 구조가 재구성되어 가독성과 유지보수성이 향상되었습니다.
  * 불필요한 텍스트 및 복잡한 레이아웃이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->