### PR TITLE
Fix: findDOMNode -> nodeRef 부여 방식으로 변경

### DIFF
--- a/src/components/Common/TransitionRoutes.tsx
+++ b/src/components/Common/TransitionRoutes.tsx
@@ -45,6 +45,10 @@ const TransitionRoutes: FC<TransitionRoutesProps> = ({ children }) => {
   };
   const nodeRef = getNodeRef(transitionKey);
 
+  const removeNodeRef = (key: string) => {
+    nodeRefMap.current.delete(key);
+  };
+
   // exit하는 child에게도 현재의 classNames 적용
   const childFactory = (child: ReactElement) => {
     return cloneElement(child, {
@@ -66,6 +70,7 @@ const TransitionRoutes: FC<TransitionRoutesProps> = ({ children }) => {
         timeout={timeout}
         mountOnEnter
         unmountOnExit
+        onExited={() => removeNodeRef(transitionKey)}
       >
         <div ref={nodeRef} className="transition-page-wrapper">
           <Routes location={location}>{children}</Routes>

--- a/src/components/Common/TransitionRoutes.tsx
+++ b/src/components/Common/TransitionRoutes.tsx
@@ -1,4 +1,12 @@
-import { FC, ReactNode, cloneElement, createRef, useRef } from 'react';
+import {
+  FC,
+  ReactElement,
+  ReactNode,
+  RefObject,
+  cloneElement,
+  createRef,
+  useRef,
+} from 'react';
 import { Routes, useLocation } from 'react-router-dom';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { getPageTransitionConfig } from '@/constants/pageTransition';
@@ -26,7 +34,7 @@ const TransitionRoutes: FC<TransitionRoutesProps> = ({ children }) => {
   const transitionKey = location.pathname;
 
   // findDOMNode 경고 방지를 위해 경로별 nodeRef 관리
-  const nodeRefMap = useRef(new Map<string, React.RefObject<HTMLDivElement>>());
+  const nodeRefMap = useRef(new Map<string, RefObject<HTMLDivElement>>());
   const getNodeRef = (key: string) => {
     let ref = nodeRefMap.current.get(key);
     if (!ref) {
@@ -38,7 +46,7 @@ const TransitionRoutes: FC<TransitionRoutesProps> = ({ children }) => {
   const nodeRef = getNodeRef(transitionKey);
 
   // exit하는 child에게도 현재의 classNames 적용
-  const childFactory = (child: React.ReactElement) => {
+  const childFactory = (child: ReactElement) => {
     return cloneElement(child, {
       classNames: classNames,
     });

--- a/src/components/Common/TransitionRoutes.tsx
+++ b/src/components/Common/TransitionRoutes.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, cloneElement } from 'react';
+import { FC, ReactNode, cloneElement, createRef, useRef } from 'react';
 import { Routes, useLocation } from 'react-router-dom';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { getPageTransitionConfig } from '@/constants/pageTransition';
@@ -25,6 +25,18 @@ const TransitionRoutes: FC<TransitionRoutesProps> = ({ children }) => {
   // 페이지 경로만 키로 사용
   const transitionKey = location.pathname;
 
+  // findDOMNode 경고 방지를 위해 경로별 nodeRef 관리
+  const nodeRefMap = useRef(new Map<string, React.RefObject<HTMLDivElement>>());
+  const getNodeRef = (key: string) => {
+    let ref = nodeRefMap.current.get(key);
+    if (!ref) {
+      ref = createRef<HTMLDivElement>();
+      nodeRefMap.current.set(key, ref);
+    }
+    return ref;
+  };
+  const nodeRef = getNodeRef(transitionKey);
+
   // exit하는 child에게도 현재의 classNames 적용
   const childFactory = (child: React.ReactElement) => {
     return cloneElement(child, {
@@ -42,11 +54,12 @@ const TransitionRoutes: FC<TransitionRoutesProps> = ({ children }) => {
       <CSSTransition
         key={transitionKey}
         classNames={classNames}
+        nodeRef={nodeRef}
         timeout={timeout}
         mountOnEnter
         unmountOnExit
       >
-        <div className="transition-page-wrapper">
+        <div ref={nodeRef} className="transition-page-wrapper">
           <Routes location={location}>{children}</Routes>
         </div>
       </CSSTransition>


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #470 

## Work Description ✏️

- `TransitionRoutes` 내부 findDOMNode 사용 제거

## Uncompleted Tasks 😅

## To Reviewers 📢

- 기존 방식에서는 `CSSTransition` 에 별도의 nodeRef가 할당되지 않아, findDOMNode로 자식의 실제 DOM을 탐색중이었습니다.
- 자식이 최상위의 라우트 페이지 그 자체인 `div.transition-page-wrapper` 였기 때문에, `findDOMNode` 로 항상 div를 정확히 탐색할 수 있어 페이지 전환 애니메이션 자체는 정상적으로 동작하고 있었습니다.
- `nodeRef`를 경로 키(location.pathname)별로 관리하도록 `Map` + `createRef`를 사용해 CSSTransition에 `nodeRef`를 전달하고, 해당 ref를 실제 DOM 에 연결하는 방식으로 기존 로직을 유지하면서 `findDOMNode`를 사용하지 않도록 변경했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 경로 전환 시 발생하던 경고 메시지를 방지하기 위해 트랜지션 애니메이션 처리 방식을 개선하였습니다.  
  * 내부적으로 명시적인 노드 참조 방식을 적용하여 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->