### PR TITLE
[Fix/472] Card 내 Tag/Divider 시각 통일 및 토큰 적용

### DIFF
--- a/src/components/Common/EmployeeCard/EmployeeCard.tsx
+++ b/src/components/Common/EmployeeCard/EmployeeCard.tsx
@@ -49,7 +49,7 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
             padding="py-[0.188rem] px-[0.313rem]"
             isRounded={true}
             hasCheckIcon={false}
-            backgroundColor="bg-status-blue-300/10"
+            backgroundColor="bg-status-blue-100"
             color="text-text-success"
             fontStyle="caption-12-semibold"
           />

--- a/src/components/Common/EmployeeCard/EmployeeCard.tsx
+++ b/src/components/Common/EmployeeCard/EmployeeCard.tsx
@@ -46,7 +46,7 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
         <div className="pt-2 flex items-center gap-1 flex-wrap">
           <Tag
             value={cardData?.industry}
-            padding="py-[0.188rem] px-[0.313rem]"
+            padding="pt-[0.188rem] pb-[0.25rem] px-[0.375rem]"
             isRounded={true}
             hasCheckIcon={false}
             backgroundColor="bg-status-blue-100"
@@ -55,7 +55,7 @@ const EmployeeCard = ({ cardData, variant }: EmployeeCardProps) => {
           />
           <Tag
             value={cardData?.visa?.replace(/_/g, '-')}
-            padding="py-[0.188rem] px-[0.313rem]"
+            padding="pt-[0.188rem] pb-[0.25rem] px-[0.375rem]"
             isRounded={true}
             hasCheckIcon={false}
             backgroundColor="bg-surface-secondary"

--- a/src/components/Common/JobPostingCard.tsx
+++ b/src/components/Common/JobPostingCard.tsx
@@ -59,7 +59,7 @@ const CardDeadLineTag = () => {
       padding="px-[0.313rem] py-[0.188rem]"
       isRounded={false}
       hasCheckIcon={false}
-      backgroundColor="bg-status-error/10"
+      backgroundColor="bg-status-red-100"
       color="text-text-error"
       fontStyle="caption-11-semibold"
     />
@@ -179,7 +179,7 @@ const CardTagList = () => {
         padding="pt-[0.188rem] pb-[0.25rem] px-[0.375rem]"
         isRounded={true}
         hasCheckIcon={false}
-        backgroundColor="bg-status-success/10"
+        backgroundColor="bg-status-blue-100"
         color="text-text-success"
         fontStyle="caption-12-semibold"
       />

--- a/src/components/Common/JobPostingCard.tsx
+++ b/src/components/Common/JobPostingCard.tsx
@@ -100,7 +100,7 @@ const CardCompanyInfo = () => {
   return (
     <p className="body-14-regular text-text-normal whitespace-normal flex items-center">
       {company_name}
-      <span className="w-0.5 h-0.5 bg-border-normal rounded-full mx-1"></span>
+      <span className="w-0.5 h-0.5 bg-neutral-500 rounded-full mx-1"></span>
       {summaries?.address?.split(' ')?.slice(0, 2)?.join(' ') ?? ''}
     </p>
   );
@@ -123,7 +123,7 @@ const CardVisa = () => {
   const { tags } = useCard();
 
   return (
-    <span className="body-14-regular text-text-normal whitespace-normal items-center">
+    <span className="body-14-regular text-text-normal whitespace-normal items-center align-middle">
       {tags.visa.sort().join(', ').replace(/_/g, '-')}
     </span>
   );
@@ -139,7 +139,7 @@ const CardWorkDayInfo = () => {
       : summaries.work_period?.replace(/_/g, ' ').toLowerCase();
 
   return (
-    <span className="body-14-regular text-text-normal whitespace-normal items-center">
+    <span className="body-14-regular text-text-normal whitespace-normal items-center align-middle">
       {workDaysPerWeekToText(
         summaries.work_days_per_week as string,
         account_type,

--- a/src/components/Home/HomeCareerPostCard.tsx
+++ b/src/components/Home/HomeCareerPostCard.tsx
@@ -53,7 +53,7 @@ const HomeCareerPostCard = ({ careerData }: HomeCareerPostCardProps) => {
             </h3>
             <p className="caption-12-regular text-text-alternative whitespace-normal flex items-center">
               {careerData.organizer_name ?? '-'}
-              <span className="w-px h-2.5 bg-border-alternative mx-1"></span>
+              <span className="w-0.5 h-0.5 bg-neutral-500 rounded-full mx-1"></span>
               {careerData.host_name ?? '-'}
             </p>
           </div>

--- a/src/components/Home/HomeCareerPostCard.tsx
+++ b/src/components/Home/HomeCareerPostCard.tsx
@@ -60,7 +60,7 @@ const HomeCareerPostCard = ({ careerData }: HomeCareerPostCardProps) => {
 
           <div className="flex flex-wrap items-center gap-1">
             {careerData.career_category && (
-              <span className="caption-11-semibold bg-[#0066FF1F] text-text-success py-[0.188rem] px-[0.313rem] rounded-md">
+              <span className="caption-11-semibold bg-status-blue-100 text-text-success py-[0.188rem] px-[0.313rem] rounded-md">
                 {CAREER_CATEGORY[careerData.career_category]}
               </span>
             )}

--- a/src/components/Home/HomePostCard.tsx
+++ b/src/components/Home/HomePostCard.tsx
@@ -77,7 +77,7 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
               padding="py-[0.188rem] px-[0.313rem]"
               isRounded={false}
               hasCheckIcon={false}
-              backgroundColor="bg-[#0066FF1F]"
+              backgroundColor="bg-status-blue-100"
               color="text-text-success"
               fontStyle="caption-11-semibold"
             />

--- a/src/components/Home/HomePostCard.tsx
+++ b/src/components/Home/HomePostCard.tsx
@@ -61,7 +61,7 @@ const HomePostCard = ({ jobPostingData }: HomePostCardProps) => {
             </h3>
             <p className="caption-12-regular text-text-alternative whitespace-normal flex items-center">
               {jobPostingData.company_name}
-              <span className="w-px h-2.5 bg-border-alternative mx-1"></span>
+              <span className="w-0.5 h-0.5 bg-neutral-500 rounded-full mx-1"></span>
               {jobPostingData.summaries.address.split(' ').slice(0, 2).join(' ')}
             </p>
           </div>

--- a/src/components/PostSearch/CareerCardList.tsx
+++ b/src/components/PostSearch/CareerCardList.tsx
@@ -72,15 +72,15 @@ const CareerCard = ({ careerData }: { careerData: CareerListItemType }) => {
           )}
         </div>
       </div>
-      <p className="pb-4 whitespace-normal caption-12-regular text-text-alternative">
+      <p className="pb-4 whitespace-normal caption-12-regular text-text-alternative flex items-center">
         {careerData.career_category &&
           CAREER_CATEGORY[careerData.career_category]}
-        <span className="mx-2 inline-block px-[0.063rem] h-3 bg-border-alternative align-middle"></span>
+        <span className="w-0.5 h-0.5 bg-neutral-500 rounded-full mx-1"></span>
         {careerData.visa?.join(', ')?.replace(/_/g, '-')}
       </p>
-      <p className="pb-1 whitespace-normal button-14-semibold text-text-normal">
+      <p className="pb-1 whitespace-normal button-14-semibold text-text-strong flex items-center">
         {careerData.organizer_name}
-        <span className="mx-2 inline-block px-[0.063rem] h-3 bg-border-alternative align-middle"></span>
+        <span className="w-0.5 h-0.5 bg-neutral-600 rounded-full mx-1"></span>
         {careerData.host_name}
       </p>
       <div className="flex items-center justify-between w-full">

--- a/src/components/PostSearch/CareerCardList.tsx
+++ b/src/components/PostSearch/CareerCardList.tsx
@@ -52,7 +52,7 @@ const CareerCard = ({ careerData }: { careerData: CareerListItemType }) => {
         padding="px-1 py-[0.188rem]"
         isRounded={false}
         hasCheckIcon={false}
-        backgroundColor="bg-[#FF5252]/10"
+        backgroundColor="bg-status-red-100"
         color="text-text-error"
         fontStyle="caption-12-regular"
       />

--- a/src/components/PostSearch/CareerCardList.tsx
+++ b/src/components/PostSearch/CareerCardList.tsx
@@ -49,12 +49,12 @@ const CareerCard = ({ careerData }: { careerData: CareerListItemType }) => {
     >
       <Tag
         value={formatLeftDays()}
-        padding="px-1 py-[0.188rem]"
+        padding="px-[0.313rem] py-[0.188rem]"
         isRounded={false}
         hasCheckIcon={false}
         backgroundColor="bg-status-red-100"
         color="text-text-error"
-        fontStyle="caption-12-regular"
+        fontStyle="caption-11-semibold"
       />
       <div className="flex items-center justify-between w-full py-1">
         <h3 className="heading-18-semibold text-text-strong line-clamp-2">

--- a/src/components/PostSearch/PostCardList.tsx
+++ b/src/components/PostSearch/PostCardList.tsx
@@ -77,9 +77,9 @@ const PostCardList = ({
                 <JobPostingCard.CompanyInfo />
               </div>
               <JobPostingCard.HourlyRate />
-              <p className="pt-[0.125rem] pb-2 caption-12-regular text-text-alternative whitespace-normal">
+              <p className="pt-[0.125rem] pb-2 caption-12-regular text-text-alternative whitespace-normal items-center">
                 <JobPostingCard.Visa />
-                <span className="mx-2 inline-block px-[0.063rem] h-3 bg-border-alternative align-middle"></span>
+                <span className="inline-block w-0.5 h-0.5 bg-neutral-500 rounded-full mx-1 align-middle"></span>
                 <JobPostingCard.WorkDayInfo />
               </p>
               <JobPostingCard.TagList />


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closed #472 


## Work Description ✏️

[//]: # "작업 내용 간단 소개"

기존 카드 컴포넌트(JobPostingCard 등) 내에서 사용되는 **Tag**와 **Divider** 스타일이 일관되지 않아, 다음 기준에 맞춰 통합 및 개선하였습니다. (일부 Tag의 배경색상이 렌더되지 않은 이슈 존재)

- Tag 배경색을 디자인 시스템 기준 색상 토큰으로 적용
- Tag 스펙(일부 Padding, TextStyle) 수정
- 카드 내부 Divider 여백 및 색상 통일 (line기반의 divider -> dot기반의 divider)
  - **PostCardList.tsx** 의 경우, dotDivider가 포함된 노드가 flex-wrap 되어 있는 특성을 고려하여, **JobPostingCard.tsx** 에 정의되어 있는 각 `<JobPostingCard.Visa />`와  `<JobPostingCard.WorkDayInfo />` 에 `align-middle` 을 추가하였습니다.
  - **PostCardList.tsx** 의 경우, 다른 dotDivider 와 달리 `inline-block` 속성이 추가되어 있습니다.



## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

N/A

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 여러 카드 컴포넌트에서 태그와 구분선의 배경색, 패딩, 정렬 등 시각적 스타일이 개선되었습니다.
  * 세로 직선 구분선이 작은 원형 점으로 변경되어 정보 구분이 더 명확해졌습니다.
  * 태그의 배경색이 일관된 색상 클래스로 통일되어 시각적 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->